### PR TITLE
fix(auth): redirect unauthenticated users from dashboard routes

### DIFF
--- a/apps/frontend/src/app/dashboard/layout.tsx
+++ b/apps/frontend/src/app/dashboard/layout.tsx
@@ -44,6 +44,11 @@ const Layout = ({ children }: { children: ReactNode }) => {
           localStorage.getItem("walletAddress") ||
           localStorage.getItem("address-wallet");
 
+        if (!isPublic && !address && !hasWalletInStorage) {
+          router.replace("/login");
+          return;
+        }
+
         setIsLoading(false);
       } catch (error) {
         console.error("Authentication error:", error);


### PR DESCRIPTION
## Fix: Dashboard layout auth guard does not redirect unauthenticated users

Closes #129

### Summary

Adds an authentication guard to dashboard routes and redirects unauthenticated users to `/login`.

### Changes

* Enforce auth checks in `dashboard/layout.tsx`
* Redirect unauthenticated users using `router.replace("/login")`
* Prevent protected content from rendering before redirect

### Testing

* Verified unauthenticated users are redirected to `/login`
* Verified authenticated users can access dashboard routes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unauthenticated users are now properly redirected to the login page when attempting to access protected dashboard routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->