### PR TITLE
fix(header): replace hardcoded user identity with authenticated store…

### DIFF
--- a/apps/frontend/src/components/layouts/Header.tsx
+++ b/apps/frontend/src/components/layouts/Header.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { Bell, Menu } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SearchHeader } from "@/components/layouts/SearchHeader";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
+import { useGlobalAuthenticationStore } from "@/core/store/data";
 
 
 interface HeaderProps {
@@ -13,6 +15,26 @@ interface HeaderProps {
 }
 
 export const Header = ({ onMenuClick }: HeaderProps) => {
+  const { address } = useGlobalAuthenticationStore();
+  const [activeAddress, setActiveAddress] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (address) {
+      setActiveAddress(address);
+    } else {
+      const fallback =
+        localStorage.getItem("walletAddress") ||
+        localStorage.getItem("address-wallet");
+      setActiveAddress(fallback);
+    }
+  }, [address]);
+
+  // TODO: wire in Batch N — replace with real user name from Hasura
+  // once GET_CURRENT_USER query is wired
+  const displayName = activeAddress
+    ? `${activeAddress.slice(0, 4)}...${activeAddress.slice(-4)}`
+    : "Account";
+  const initials = "ST"; // SafeTrust fallback
   return (
     <>
       <header className="fixed top-0 left-0 right-0 z-50 bg-white shadow-sm dark:border-b dark:border-gray-800 dark:bg-gray-900">
@@ -65,11 +87,11 @@ export const Header = ({ onMenuClick }: HeaderProps) => {
                 className="flex items-center gap-2 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full px-2 py-1 transition-colors"
               >
                 <span className="hidden md:block text-sm font-medium text-gray-700 dark:text-gray-200">
-                  Randall Valenciano
+                  {displayName}
                 </span>
                 <div className="w-8 h-8 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center shrink-0">
                   <span className="text-xs font-semibold text-gray-600 dark:text-gray-300">
-                    RV
+                    {initials}
                   </span>
                 </div>
               </button>

--- a/apps/frontend/src/components/layouts/Header.tsx
+++ b/apps/frontend/src/components/layouts/Header.tsx
@@ -15,26 +15,31 @@ interface HeaderProps {
 }
 
 export const Header = ({ onMenuClick }: HeaderProps) => {
+  const safeGetItem = (key: string): string | null => {
+    try {
+      return localStorage.getItem(key);
+    } catch {
+      return null;
+    }
+  };
+
   const { address } = useGlobalAuthenticationStore();
-  const [activeAddress, setActiveAddress] = useState<string | null>(null);
+  const [fallbackAddress, setFallbackAddress] = useState<string | null>(null);
 
   useEffect(() => {
-    if (address) {
-      setActiveAddress(address);
-    } else {
-      const fallback =
-        localStorage.getItem("walletAddress") ||
-        localStorage.getItem("address-wallet");
-      setActiveAddress(fallback);
-    }
-  }, [address]);
+    const fallback = safeGetItem("walletAddress") || safeGetItem("address-wallet");
+    setFallbackAddress(fallback);
+  }, []);
 
-  // TODO: wire in Batch N — replace with real user name from Hasura
-  // once GET_CURRENT_USER query is wired
+  const activeAddress = address || fallbackAddress;
+
   const displayName = activeAddress
     ? `${activeAddress.slice(0, 4)}...${activeAddress.slice(-4)}`
     : "Account";
-  const initials = "ST"; // SafeTrust fallback
+
+  const initials = activeAddress
+    ? (activeAddress.startsWith("0x") ? activeAddress.slice(2, 4) : activeAddress.slice(0, 2)).toUpperCase() || "AC"
+    : "AC";
   return (
     <>
       <header className="fixed top-0 left-0 right-0 z-50 bg-white shadow-sm dark:border-b dark:border-gray-800 dark:bg-gray-900">


### PR DESCRIPTION
## Fix: Replace hardcoded user identity in Header

Closes #131

### Summary

Replaces the hardcoded user identity in the dashboard header with authenticated user data.

### Changes

* Read wallet address from authentication state
* Added fallback handling to ensure the wallet address is displayed after page refresh
* Replaced hardcoded user name and initials
* Display shortened wallet address when available
* Use `ST` as the default fallback initials

### Testing

* Verified connected users see their wallet address in the header
* Verified header identity persists correctly after page refresh
* Verified fallback state displays correctly when no wallet is connected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Header now dynamically displays authenticated user's account name and avatar initials based on current session state instead of hardcoded values.
  * Includes localStorage-backed fallback to maintain account information across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->