### PR TITLE
fix: use resolvedTheme in ThemeToggle to correctly handle system theme default

### DIFF
--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <ClientProviders>

--- a/apps/frontend/src/components/ui/theme-toggle.tsx
+++ b/apps/frontend/src/components/ui/theme-toggle.tsx
@@ -4,15 +4,15 @@ import { useTheme } from "next-themes";
 import { Sun, Moon } from "lucide-react";
 
 export function ThemeToggle() {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
 
   return (
     <button
-      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+      onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
       className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
       aria-label="Toggle theme"
     >
-      {theme === "dark" ? (
+      {resolvedTheme === "dark" ? (
         <Sun className="w-5 h-5 text-yellow-500" />
       ) : (
         <Moon className="w-5 h-5 text-gray-600" />

--- a/apps/frontend/src/components/ui/theme-toggle.tsx
+++ b/apps/frontend/src/components/ui/theme-toggle.tsx
@@ -2,9 +2,15 @@
 
 import { useTheme } from "next-themes";
 import { Sun, Moon } from "lucide-react";
+import { useEffect, useState } from "react";
 
 export function ThemeToggle() {
   const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) return null;
 
   return (
     <button


### PR DESCRIPTION
Closes #128

## Problem
ThemeProvider is configured with defaultTheme="system" and enableSystem, 
which means useTheme().theme can return "system" instead of "dark" or "light". 
The previous toggle logic used theme === "dark" which evaluated to false when 
the value was "system", causing the icon and click handler to behave incorrectly 
on first render.

## Solution
Replaced theme with resolvedTheme from useTheme(), which always returns the 
actual computed value ("dark" or "light") by resolving the system preference.

## Changes
- `apps/frontend/src/components/ui/theme-toggle.tsx`: replaced `theme` with `resolvedTheme` in destructure, onClick handler, and icon conditional

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme toggle reliability so it accurately detects and active theme.
  * Prevented rendering before the theme is resolved to avoid flashing the wrong theme on load.
  * Ensured toggle actions consistently switch to the opposite theme, matching system preferences.
  * Reduced hydration mismatch issues to further prevent UI flicker on initial load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->