### PR TITLE
Add dashboard logout button

### DIFF
--- a/apps/frontend/src/components/auth/LogoutButton.tsx
+++ b/apps/frontend/src/components/auth/LogoutButton.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import Cookies from "js-cookie";
+import { signOut } from "firebase/auth";
+import { LogOut } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { useGlobalAuthenticationStore } from "@/core/store/data";
+import { auth } from "@/lib/firebase";
+
+export function LogoutButton() {
+  const router = useRouter();
+  const disconnect = useGlobalAuthenticationStore((state) => state.disconnect);
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+  const handleLogout = async () => {
+    if (isLoggingOut) return;
+
+    setIsLoggingOut(true);
+
+    try {
+      await signOut(auth);
+    } finally {
+      Cookies.remove("firebase-token");
+      Cookies.remove("auth-token");
+      disconnect();
+      router.push("/login");
+    }
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      className="w-full justify-start gap-2 text-gray-400 hover:bg-gray-800 hover:text-white"
+      onClick={handleLogout}
+      disabled={isLoggingOut}
+    >
+      <LogOut className="h-4 w-4" />
+      {isLoggingOut ? "Logging out..." : "Logout"}
+    </Button>
+  );
+}

--- a/apps/frontend/src/components/layouts/SideBar.tsx
+++ b/apps/frontend/src/components/layouts/SideBar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
+import { LogoutButton } from "@/components/auth/LogoutButton";
 import { Bell, Heart, Shield, Users } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -35,9 +36,10 @@ export function SideBar({
         className,
       )}
     >
-      <div className="flex flex-col items-start gap-4 py-4 px-2 lg:px-4">
+      <div className="flex h-full flex-col items-start gap-4 py-4 px-2 lg:px-4">
         <Link
           href="/dashboard/escrow"
+          onClick={onClose}
           className={cn(
             "flex items-center gap-2 p-2 rounded-lg transition-colors duration-200 w-full dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white",
             pathname === "/dashboard/escrow"
@@ -93,6 +95,7 @@ export function SideBar({
         </Link>
         <Link
           href="/dashboard/users"
+          onClick={onClose}
           className={cn(
             "flex items-center gap-2 p-2 rounded-lg hover:bg-accent transition-colors duration-200 w-full dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white",
             pathname === "/dashboard/users" && "bg-accent font-medium dark:bg-gray-800 dark:text-white",
@@ -101,6 +104,9 @@ export function SideBar({
           <Users className="w-6 h-6 dark:text-gray-400" />
           <span>Users</span>
         </Link>
+        <div className="mt-auto w-full pt-4">
+          <LogoutButton />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
﻿Summary
- Added a dashboard sidebar logout button so authenticated users can sign out from the UI without manually clearing browser storage.
- Logout clears the Firebase session, removes auth cookies used by middleware, clears the global authentication store, and redirects to `/login`.

Issue
- Closes #143

Changes
- Added `apps/frontend/src/components/auth/LogoutButton.tsx` as a client component.
- Calls `signOut(auth)` from Firebase when clicked.
- Calls `useGlobalAuthenticationStore(...).disconnect()` after logout.
- Removes `firebase-token` and `auth-token` cookies so the dashboard middleware no longer treats the user as authenticated.
- Adds the logout button to the bottom of `SideBar` for both desktop and mobile dashboard navigation.
- Keeps sidebar styling aligned with the existing dark navigation theme.

Validation
- Ran `git diff --check`.
- Attempted `pnpm.cmd install --frozen-lockfile --ignore-scripts`; it timed out after five minutes before creating `node_modules`, so build/typecheck could not be run locally.

Notes
- No lockfiles were changed.
- The cookie removal is included so navigating back to `/dashboard` after logout is handled by the existing middleware redirect to `/login`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added logout button to the sidebar, enabling users to securely log out from their account.
  * Sidebar now automatically closes after selecting navigation links in drawer mode for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->