### PR TITLE
feat(dashboard): add guest browse view with filters and apartment grid

### DIFF
--- a/apps/frontend/src/app/dashboard/guest/page.tsx
+++ b/apps/frontend/src/app/dashboard/guest/page.tsx
@@ -1,11 +1,143 @@
-import GuestDashboard from "@/components/dashboard/guest/GuestDashboard";
-import { HotelHeader } from "@/components/hotel";
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { LayoutDashboard } from "lucide-react";
+import { ApartmentCard } from "@/components/guest/ApartmentCard";
+import { CategoryFilter } from "@/components/guest/CategoryFilter";
+import { LocationFilter } from "@/components/guest/LocationFilter";
+import { BedroomTabs } from "@/components/guest/BedroomTabs";
+
+// TODO: replace with Hasura query → public.apartments
+const STUB_APARTMENTS = Array.from({ length: 6 }, (_, i) => ({
+  id: String(i + 1),
+  name: "La sabana sur",
+  address: "329 Calle santos, paseo colón, San José",
+  price: 4058,
+  beds: 2,
+  baths: 1,
+  petFriendly: true,
+  isPromoted: i === 0 || i === 4,
+  isFavorite: i === 2,
+}));
 
 export default function GuestDashboardPage() {
+  const router = useRouter();
+
+  const [categories, setCategories] = useState<string[]>(
+    ["Family", "Students"]
+  );
+  const [locations, setLocations] = useState<string[]>(
+    ["San José", "Heredia"]
+  );
+  const [bedrooms, setBedrooms]   = useState("all");
+  const [favorites, setFavorites] = useState<string[]>(["3"]);
+
+  const toggleFavorite = (id: string) =>
+    setFavorites((prev) =>
+      prev.includes(id)
+        ? prev.filter((f) => f !== id)
+        : [...prev, id]
+    );
+
   return (
-    <div className="min-h-screen bg-white">
-      <HotelHeader />
-      <GuestDashboard />
+    <div className="flex min-h-screen bg-white">
+
+      {/* ── Left filters sidebar ── */}
+      <aside className="w-64 border-r border-gray-200
+                        p-6 space-y-8 shrink-0">
+        <CategoryFilter
+          selected={categories}
+          onChange={setCategories}
+        />
+
+        {/* Price range */}
+        <div className="space-y-2">
+          <h3 className="text-sm font-semibold text-gray-700">
+            Price Range
+          </h3>
+          <p className="text-sm text-gray-500">
+            $ 3,200 - $206,000
+          </p>
+          {/* TODO: wire real range slider component */}
+          <div className="relative h-2 bg-orange-100 rounded-full">
+            <div className="absolute inset-y-0 left-[10%]
+                            right-[25%] bg-orange-500
+                            rounded-full" />
+            <div className="absolute top-1/2 left-[10%]
+                            -translate-x-1/2 -translate-y-1/2
+                            h-4 w-4 rounded-full bg-orange-500
+                            border-2 border-white shadow" />
+            <div className="absolute top-1/2 left-[75%]
+                            -translate-x-1/2 -translate-y-1/2
+                            h-4 w-4 rounded-full bg-orange-500
+                            border-2 border-white shadow" />
+          </div>
+        </div>
+
+        <LocationFilter
+          selected={locations}
+          onChange={setLocations}
+        />
+      </aside>
+
+      {/* ── Main content ── */}
+      <main className="flex-1 p-6 space-y-4">
+
+        {/* Header row */}
+        <div className="flex items-start justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">
+              Available for rent in{" "}
+              <span className="font-extrabold">
+                Costa Rica, San José
+              </span>
+            </h1>
+            <p className="text-sm text-gray-500 mt-0.5">
+              204 units available
+            </p>
+          </div>
+          <div className="flex items-center gap-4">
+            <div className="flex items-center gap-1
+                            text-sm text-gray-500">
+              <span>↕ Sort by:</span>
+              <span className="text-orange-500 font-medium
+                               cursor-pointer">
+                Relevance ▾
+              </span>
+            </div>
+            {/* Switch to Host view */}
+            <button
+              onClick={() => router.push("/dashboard")}
+              className="flex items-center gap-1.5 text-sm
+                         font-medium text-orange-500
+                         hover:text-orange-600 transition-colors"
+            >
+              <LayoutDashboard className="h-4 w-4" />
+              Switch to Host view
+            </button>
+          </div>
+        </div>
+
+        {/* Bedroom tabs */}
+        <BedroomTabs
+          selected={bedrooms}
+          onChange={setBedrooms}
+        />
+
+        {/* Apartment grid */}
+        <div className="grid grid-cols-3 gap-4">
+          {STUB_APARTMENTS.map((apt) => (
+            <ApartmentCard
+              key={apt.id}
+              {...apt}
+              isFavorite={favorites.includes(apt.id)}
+              onFavoriteToggle={toggleFavorite}
+            />
+          ))}
+        </div>
+
+      </main>
     </div>
   );
 }

--- a/apps/frontend/src/app/dashboard/guest/page.tsx
+++ b/apps/frontend/src/app/dashboard/guest/page.tsx
@@ -14,9 +14,11 @@ const STUB_APARTMENTS = Array.from({ length: 6 }, (_, i) => ({
   name: "La sabana sur",
   address: "329 Calle santos, paseo colón, San José",
   price: 4058,
-  beds: 2,
+  beds: i === 2 ? 1 : i === 3 ? 3 : 2,
   baths: 1,
   petFriendly: true,
+  category: i % 3 === 0 ? "Family" : i % 3 === 1 ? "Students" : "Travelers",
+  location: i % 2 === 0 ? "San José" : "Heredia",
   isPromoted: i === 0 || i === 4,
   isFavorite: i === 2,
 }));
@@ -39,6 +41,13 @@ export default function GuestDashboardPage() {
         ? prev.filter((f) => f !== id)
         : [...prev, id]
     );
+
+  const filteredApartments = STUB_APARTMENTS.filter((apt) => {
+    if (categories.length > 0 && !categories.includes(apt.category)) return false;
+    if (locations.length > 0 && !locations.includes(apt.location)) return false;
+    if (bedrooms !== "all" && String(apt.beds) !== bedrooms) return false;
+    return true;
+  });
 
   return (
     <div className="flex min-h-screen bg-white">
@@ -127,7 +136,7 @@ export default function GuestDashboardPage() {
 
         {/* Apartment grid */}
         <div className="grid grid-cols-3 gap-4">
-          {STUB_APARTMENTS.map((apt) => (
+          {filteredApartments.map((apt) => (
             <ApartmentCard
               key={apt.id}
               {...apt}

--- a/apps/frontend/src/app/dashboard/layout.tsx
+++ b/apps/frontend/src/app/dashboard/layout.tsx
@@ -15,6 +15,7 @@ const PUBLIC_ROUTES = [
   "/dashboard/hotel/search",
   "/dashboard/hotel/escrow",
   "/dashboard/hotel/create-escrow",
+  "/dashboard/guest",
 ];
 
 // Routes that match patterns (for dynamic routes)
@@ -62,7 +63,13 @@ const Layout = ({ children }: { children: ReactNode }) => {
 
   // Show loading state
   if (isLoading) {
-    return (
+  const isGuestRoute = pathname === "/dashboard/guest";
+
+  if (isGuestRoute) {
+    return <>{children}</>;
+  }
+
+  return (
       <div className="flex h-screen items-center justify-center">
         {/* biome-ignore lint/style/useSelfClosingElements: <explanation> */}
         <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>

--- a/apps/frontend/src/app/dashboard/layout.tsx
+++ b/apps/frontend/src/app/dashboard/layout.tsx
@@ -61,15 +61,15 @@ const Layout = ({ children }: { children: ReactNode }) => {
     setIsSidebarOpen(false);
   }, [pathname]);
 
-  // Show loading state
-  if (isLoading) {
   const isGuestRoute = pathname === "/dashboard/guest";
 
   if (isGuestRoute) {
     return <>{children}</>;
   }
 
-  return (
+  // Show loading state
+  if (isLoading) {
+    return (
       <div className="flex h-screen items-center justify-center">
         {/* biome-ignore lint/style/useSelfClosingElements: <explanation> */}
         <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>

--- a/apps/frontend/src/components/guest/ApartmentCard.tsx
+++ b/apps/frontend/src/components/guest/ApartmentCard.tsx
@@ -53,6 +53,8 @@ export function ApartmentCard({
               e.stopPropagation();
               onFavoriteToggle?.(id);
             }}
+            aria-label={`Toggle favorite for apartment ${id}`}
+            aria-pressed={isFavorite}
           >
             <Heart className={cn(
               "h-4 w-4 transition-colors",

--- a/apps/frontend/src/components/guest/ApartmentCard.tsx
+++ b/apps/frontend/src/components/guest/ApartmentCard.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { Heart } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface ApartmentCardProps {
+  id: string;
+  name: string;
+  address: string;
+  price: number;
+  beds: number;
+  baths: number;
+  petFriendly: boolean;
+  isPromoted?: boolean;
+  isFavorite?: boolean;
+  onFavoriteToggle?: (id: string) => void;
+}
+
+export function ApartmentCard({
+  id, name, address, price, beds, baths,
+  petFriendly, isPromoted = false,
+  isFavorite = false, onFavoriteToggle,
+}: ApartmentCardProps) {
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white
+                    overflow-hidden hover:shadow-md
+                    transition-shadow cursor-pointer">
+
+      {/* Image placeholder */}
+      <div className="relative h-40 bg-gradient-to-br
+                      from-gray-200 to-gray-300">
+        {isPromoted && (
+          <span className="absolute bottom-2 left-2 bg-orange-500
+                           text-white text-xs px-2 py-0.5
+                           rounded-full font-medium
+                           flex items-center gap-1">
+            🔥 PROMOTED
+          </span>
+        )}
+      </div>
+
+      {/* Card info */}
+      <div className="p-3 space-y-1">
+        <div className="flex items-center justify-between">
+          <p className="text-sm font-bold text-orange-500">
+            ${price.toLocaleString()}.00
+            <span className="text-xs font-normal text-gray-400">
+              {" "}Per month
+            </span>
+          </p>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onFavoriteToggle?.(id);
+            }}
+          >
+            <Heart className={cn(
+              "h-4 w-4 transition-colors",
+              isFavorite
+                ? "fill-red-500 text-red-500"
+                : "text-gray-300 hover:text-red-400"
+            )} />
+          </button>
+        </div>
+        <p className="text-sm font-semibold text-gray-900">
+          {name}
+        </p>
+        <p className="text-xs text-gray-500 truncate">{address}</p>
+        <div className="flex items-center gap-3 text-xs
+                        text-gray-400 pt-1 border-t
+                        border-gray-100">
+          <span>🛏 {beds} bd</span>
+          {petFriendly && <span>🐾 pet friendly</span>}
+          <span>🚿 {baths} ba</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/guest/BedroomTabs.tsx
+++ b/apps/frontend/src/components/guest/BedroomTabs.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+const TABS = [
+  { label: "All apartments", value: "all" },
+  { label: "1 bedroom",      value: "1" },
+  { label: "2 bedrooms",     value: "2" },
+  { label: "3 bedrooms",     value: "3" },
+];
+
+interface BedroomTabsProps {
+  selected: string;
+  onChange: (v: string) => void;
+}
+
+export function BedroomTabs({ selected, onChange }: BedroomTabsProps) {
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      {TABS.map((tab) => (
+        <button
+          key={tab.value}
+          onClick={() => onChange(tab.value)}
+          className={cn(
+            "px-4 py-1.5 rounded-full text-sm border",
+            "transition-colors",
+            selected === tab.value
+              ? "bg-gray-900 text-white border-gray-900"
+              : "bg-white text-gray-600 border-gray-300",
+            "hover:border-gray-500"
+          )}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/guest/CategoryFilter.tsx
+++ b/apps/frontend/src/components/guest/CategoryFilter.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+const CATEGORIES = ["Family", "Students", "Travelers"];
+
+interface CategoryFilterProps {
+  selected: string[];
+  onChange: (v: string[]) => void;
+}
+
+export function CategoryFilter({
+  selected, onChange,
+}: CategoryFilterProps) {
+  const toggle = (cat: string) =>
+    onChange(
+      selected.includes(cat)
+        ? selected.filter((c) => c !== cat)
+        : [...selected, cat]
+    );
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-sm font-semibold text-gray-700">
+        Category
+      </h3>
+      {CATEGORIES.map((cat) => (
+        <label key={cat}
+          className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={selected.includes(cat)}
+            onChange={() => toggle(cat)}
+            className="rounded border-gray-300 accent-orange-500"
+          />
+          <span className="text-sm text-gray-600">{cat}</span>
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/guest/LocationFilter.tsx
+++ b/apps/frontend/src/components/guest/LocationFilter.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+const LOCATIONS = [
+  "San José", "Heredia", "Alajuela",
+  "Cartago", "Puntarenas", "Guanacaste", "Limón",
+];
+
+interface LocationFilterProps {
+  selected: string[];
+  onChange: (v: string[]) => void;
+}
+
+export function LocationFilter({
+  selected, onChange,
+}: LocationFilterProps) {
+  const toggle = (loc: string) =>
+    onChange(
+      selected.includes(loc)
+        ? selected.filter((l) => l !== loc)
+        : [...selected, loc]
+    );
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-sm font-semibold text-gray-700">
+        Location
+      </h3>
+      {LOCATIONS.map((loc) => (
+        <label key={loc}
+          className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={selected.includes(loc)}
+            onChange={() => toggle(loc)}
+            className="rounded border-gray-300 accent-orange-500"
+          />
+          <span className="text-sm text-gray-600">{loc}</span>
+        </label>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #150 

- Add /dashboard/guest route bypassing dashboard shell (no auth/sidebar)
- Create ApartmentCard with promoted badge and favorite toggle
- Create CategoryFilter, LocationFilter, BedroomTabs components
- Wire stub data for 6 apartments with orange-themed UI
- Add 'Switch to Host view' button navigating to /dashboard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Guest dashboard converted to an interactive client-rendered page with live filtering
  * Category, Location, and Bedroom filters for refining apartment results
  * Apartment cards showing monthly price, beds, baths, pet-friendly label, and “Promoted” badge
  * Favorite (heart) toggle on apartment cards
  * Quick “Switch to Host” button to change views
<!-- end of auto-generated comment: release notes by coderabbit.ai -->