### PR TITLE
Add Notifications and NotificationItem components for user alerts

### DIFF
--- a/apps/frontend/src/app/dashboard/notifications/page.tsx
+++ b/apps/frontend/src/app/dashboard/notifications/page.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useState } from "react";
+import { Bell } from "lucide-react";
+import { NotificationItem } from "@/components/dashboard/NotificationItem";
+
+// TODO: replace with real Hasura query once public.notifications table is created
+const MOCK_NOTIFICATIONS = [
+  {
+    id: "1",
+    type: "success" as const,
+    title: "Escrow funded",
+    message: "Your escrow ST-1-1714000000000 has been funded.",
+    timestamp: "Today at 10:22 AM",
+    read: false,
+  },
+  {
+    id: "2",
+    type: "info" as const,
+    title: "Bid accepted",
+    message: "Your bid on La Sabana house was accepted.",
+    timestamp: "Yesterday at 3:15 PM",
+    read: true,
+  },
+  {
+    id: "3",
+    type: "warning" as const,
+    title: "Action required",
+    message: "Sign the escrow contract before it expires.",
+    timestamp: "May 30 at 9:00 AM",
+    read: false,
+  },
+];
+
+export default function NotificationsPage() {
+  const [notifications, setNotifications] = useState(MOCK_NOTIFICATIONS);
+
+  const unreadCount = notifications.filter((n) => !n.read).length;
+
+  const markAllRead = () => {
+    setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+  };
+
+  const markRead = (id: string) => {
+    setNotifications((prev) =>
+      prev.map((n) => (n.id === id ? { ...n, read: true } : n))
+    );
+  };
+
+  return (
+    <div className="p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <h1 className="text-xl font-semibold">Notifications</h1>
+          {unreadCount > 0 && (
+            <span className="rounded-full bg-purple-600 px-2 py-0.5 text-xs text-white font-medium">
+              {unreadCount}
+            </span>
+          )}
+        </div>
+        {unreadCount > 0 && (
+          <button
+            onClick={markAllRead}
+            className="text-xs text-gray-400 hover:text-white transition-colors"
+          >
+            Mark all as read
+          </button>
+        )}
+      </div>
+
+      <hr className="border-gray-700" />
+
+      {notifications.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-16 space-y-3">
+          <Bell className="h-10 w-10 text-gray-600" />
+          <p className="text-sm font-medium text-gray-400">No notifications yet</p>
+          <p className="text-xs text-gray-500">You are all caught up</p>
+        </div>
+      )}
+
+      {notifications.length > 0 && (
+        <div className="space-y-2">
+          {notifications.map((n) => (
+            <NotificationItem
+              key={n.id}
+              type={n.type}
+              title={n.title}
+              message={n.message}
+              timestamp={n.timestamp}
+              read={n.read}
+              onClick={() => markRead(n.id)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/dashboard/NotificationItem.tsx
+++ b/apps/frontend/src/components/dashboard/NotificationItem.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Bell, CheckCircle, AlertCircle, Info } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type NotificationType = "info" | "success" | "warning";
+
+interface NotificationItemProps {
+  type: NotificationType;
+  title: string;
+  message: string;
+  timestamp: string;
+  read: boolean;
+  onClick?: () => void;
+}
+
+const TYPE_ICON: Record<NotificationType, React.ReactNode> = {
+  info:    <Info className="h-4 w-4 text-blue-400" />,
+  success: <CheckCircle className="h-4 w-4 text-green-400" />,
+  warning: <AlertCircle className="h-4 w-4 text-yellow-400" />,
+};
+
+export function NotificationItem({
+  type,
+  title,
+  message,
+  timestamp,
+  read,
+  onClick,
+}: NotificationItemProps) {
+  return (
+    <div
+      onClick={onClick}
+      className={cn(
+        "flex items-start gap-3 rounded-lg border p-4 cursor-pointer",
+        "transition-colors hover:bg-gray-800",
+        read
+          ? "border-gray-700 bg-transparent"
+          : "border-gray-600 bg-gray-800/60"
+      )}
+    >
+      <div className="mt-0.5 shrink-0">
+        {TYPE_ICON[type]}
+      </div>
+
+      <div className="flex-1 space-y-0.5">
+        <div className="flex items-center justify-between gap-2">
+          <p
+            className={cn(
+              "text-sm font-medium",
+              read ? "text-gray-400" : "text-white"
+            )}
+          >
+            {title}
+          </p>
+          {!read && (
+            <span className="h-2 w-2 rounded-full bg-purple-500 shrink-0" />
+          )}
+        </div>
+        <p className="text-xs text-gray-400">{message}</p>
+        <p className="text-xs text-gray-500">{timestamp}</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Creates the missing /notifications route that was returning a 404. Two files are added: NotificationItem.tsx — a reusable row component supporting info, success, and warning types with read/unread visual states — and notifications/page.tsx, which renders the page shell with a header, unread badge counter, "Mark all as read" action, and a mock notification list ready to be swapped for a real Hasura query. Styling follows the existing dashboard dark mode conventions. No existing files were modified.
closes #146