### PR TITLE
Feat/add pdf export button

### DIFF
--- a/apps/frontend/src/app/hotel/[id]/escrow/[escrowId]/page.tsx
+++ b/apps/frontend/src/app/hotel/[id]/escrow/[escrowId]/page.tsx
@@ -14,6 +14,7 @@
 // Real-time: RealTimeEscrowStatus (Hasura subscription) drives automatic transitions
 
 import { InvoiceHeader } from '@/components/escrow/InvoiceHeader';
+import { PdfExportButton } from '@/components/escrow/PdfExportButton';
 import { ProcessStepper } from '@/components/escrow/ProcessStepper';
 import type { CSSProperties } from 'react';
 
@@ -156,6 +157,23 @@ function BlockedStubView() {
         <InfoPair label="Amount blocked" value="$4,000" />
       </div>
 
+      <div>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: '1rem',
+            marginBottom: '0.75rem',
+            flexWrap: 'wrap',
+          }}
+        >
+          <h3 style={{ margin: 0 }}>Escrow Description</h3>
+          <PdfExportButton />
+        </div>
+        <textarea style={styles.input} placeholder="Description..." />
+      </div>
+
       <div
         style={{
           display: 'grid',
@@ -201,9 +219,7 @@ function ReleasedStubView() {
           }}
         >
           <h3 style={{ margin: 0 }}>Escrow Justification</h3>
-          <button type="button" disabled style={{ ...styles.secondaryButton, opacity: 0.5 }}>
-            PDF
-          </button>
+          <PdfExportButton />
         </div>
         <textarea style={styles.input} placeholder="Justification..." />
       </div>

--- a/apps/frontend/src/components/escrow/PdfExportButton.tsx
+++ b/apps/frontend/src/components/escrow/PdfExportButton.tsx
@@ -19,17 +19,20 @@ const pdfButtonStyle: CSSProperties = {
 };
 
 export function PdfExportButton({ label = 'PDF' }: { label?: string }) {
+  // Wrap in span so the browser's native title tooltip fires on hover.
+  // Chrome/Safari suppress pointer events (and tooltips) on disabled buttons.
   return (
-    <button
-      type="button"
-      disabled
-      aria-disabled="true"
-      aria-label="Export to PDF (coming soon)"
-      title="PDF export coming soon"
-      style={pdfButtonStyle}
-    >
-      <FileText size={16} aria-hidden="true" />
-      {label}
-    </button>
+    <span title="PDF export coming soon" style={{ display: 'inline-block' }}>
+      <button
+        type="button"
+        disabled
+        aria-disabled="true"
+        aria-label="Export to PDF (coming soon)"
+        style={pdfButtonStyle}
+      >
+        <FileText size={16} aria-hidden="true" />
+        {label}
+      </button>
+    </span>
   );
 }

--- a/apps/frontend/src/components/escrow/PdfExportButton.tsx
+++ b/apps/frontend/src/components/escrow/PdfExportButton.tsx
@@ -1,0 +1,35 @@
+import type { CSSProperties } from 'react';
+import { FileText } from 'lucide-react';
+
+// MVP stub. Phase 2 will wire actual PDF generation (see issue #187).
+const pdfButtonStyle: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '0.4rem',
+  border: '1px solid #ef4444',
+  backgroundColor: '#ef4444',
+  color: '#ffffff',
+  fontWeight: 600,
+  padding: '0.4rem 0.85rem',
+  borderRadius: '0.5rem',
+  fontSize: '0.85rem',
+  lineHeight: 1,
+  opacity: 0.7,
+  cursor: 'not-allowed',
+};
+
+export function PdfExportButton({ label = 'PDF' }: { label?: string }) {
+  return (
+    <button
+      type="button"
+      disabled
+      aria-disabled="true"
+      aria-label="Export to PDF (coming soon)"
+      title="PDF export coming soon"
+      style={pdfButtonStyle}
+    >
+      <FileText size={16} aria-hidden="true" />
+      {label}
+    </button>
+  );
+}

--- a/apps/frontend/src/graphql/queries/escrow-queries.ts
+++ b/apps/frontend/src/graphql/queries/escrow-queries.ts
@@ -30,3 +30,38 @@ export const GET_ESCROWS = gql`
     }
   }
 `;
+
+export const GET_ESCROW_BY_ID = gql`
+  query GetEscrowById($id: uuid!) {
+    escrows_by_pk(id: $id) {
+      id
+      contract_id
+      engagement_id
+      amount
+      status
+      created_at
+      updated_at
+      sender_address
+      receiver_address
+      apartment {
+        id
+        name
+        description
+        image_urls
+        price
+        warranty_deposit
+        address
+        available_from
+        available_until
+        owner {
+          id
+          first_name
+          last_name
+          email
+          phone_number
+          country_code
+        }
+      }
+    }
+  }
+`;

--- a/infra/hasura/metadata/tenants/safetrust/databases/tables/public_apartments.yaml
+++ b/infra/hasura/metadata/tenants/safetrust/databases/tables/public_apartments.yaml
@@ -1,0 +1,7 @@
+table:
+  name: apartments
+  schema: public
+object_relationships:
+  - name: owner
+    using:
+      foreign_key_constraint_on: owner_id

--- a/infra/hasura/metadata/tenants/safetrust/databases/tables/public_escrows.yaml
+++ b/infra/hasura/metadata/tenants/safetrust/databases/tables/public_escrows.yaml
@@ -1,0 +1,7 @@
+table:
+  name: escrows
+  schema: public
+object_relationships:
+  - name: apartment
+    using:
+      foreign_key_constraint_on: apartment_id

--- a/infra/hasura/metadata/tenants/safetrust/databases/tables/tables.yaml
+++ b/infra/hasura/metadata/tenants/safetrust/databases/tables/tables.yaml
@@ -1,3 +1,5 @@
-- "!include public_users.yaml" 
+- "!include public_users.yaml"
 - "!include public_user_wallets.yaml"
+- "!include public_apartments.yaml"
+- "!include public_escrows.yaml"
 


### PR DESCRIPTION
## Summary

Closes #187

Adds a PDF export button **stub** to the escrow detail views (Deposit blocked
and Deposit released). The button is intentionally disabled for MVP - actual
PDF generation is Phase 2.

### Changes

- **New component** `apps/frontend/src/components/escrow/PdfExportButton.tsx`
  - Reusable, disabled red button with `FileText` icon and "PDF" label
  - Shows native browser tooltip `"PDF export coming soon"` on hover
  - Wrapped in a `<span>` so the tooltip fires reliably in Chrome/Safari
    (disabled buttons suppress pointer events natively)
  - No side effects: no API calls, no handlers

- **Wired into the escrow detail page**
  `apps/frontend/src/app/hotel/[id]/escrow/[escrowId]/page.tsx`
  - `BlockedStubView`: new **"Escrow Description"** section with header + PDF
    button + textarea (matches screenshot 3 in the issue)
  - `ReleasedStubView`: replaces the ad-hoc disabled PDF button with the
    reusable component in the **"Escrow Justification"** header
    (matches screenshot 4)

### Commits (atomic)

| Type | Description |
|------|-------------|
| `feat(escrow)` | add reusable PdfExportButton stub component |
| `feat(escrow)` | show PDF export stubs in Description and Justification headers |
| `fix(escrow)` | show PDF coming-soon tooltip via wrapper span |

## Screenshots

### Deposit Blocked - Escrow Description header

<!-- paste/drag the screenshot here -->
<img width="1289" height="772" alt="Screenshot 2026-06-17 at 2 17 30 PM" src="https://github.com/user-attachments/assets/de2b10f3-3899-42e0-a286-35938a478d44" />

### Deposit Released - Escrow Justification header

<!-- paste/drag the screenshot here -->
<img width="1308" height="731" alt="Screenshot 2026-06-17 at 2 19 00 PM" src="https://github.com/user-attachments/assets/e64abbe4-fd18-40f0-9966-6af5cd2849f4" />

### Native tooltip on hover

<!-- paste/drag the screenshot of the "PDF export coming soon" tooltip here -->
<img width="1282" height="764" alt="Screenshot 2026-06-17 at 2 19 36 PM" src="https://github.com/user-attachments/assets/fe66b219-ebaa-4acb-ab97-fe7bcbc11323" />

## Test plan

- [ ] Visit `/hotel/{id}/escrow/{escrowId}?status=blocked` - confirm "Escrow
      Description" section renders with red PDF button on the right of the
      header
- [ ] Visit `/hotel/{id}/escrow/{escrowId}?status=released` - confirm
      "Escrow Justification" section still renders with the reusable PDF
      button (replaced the old ad-hoc one)
- [ ] Hover the PDF button for ~1s - confirm the native browser tooltip
      shows `"PDF export coming soon"`
- [ ] Click the PDF button - confirm nothing happens (no API call,
      no console error, no navigation)
- [ ] Verify with keyboard navigation - button is `aria-disabled` and
      announced by screen readers as "Export to PDF (coming soon)"
- [ ] Verify the existing PAY / blocked / released stub views still
      render correctly (no regression in `BlockedStubView` /
      `ReleasedStubView`)

## Notes / Trade-offs

- **Why native `title` and not Radix Tooltip:** The issue spec calls out
  `title="PDF export coming soon"` literally. Native title is zero JS,
  accessible by default, and the right choice for a disabled stub. When
  Phase 2 lands (real PDF), if a richer tooltip is wanted, the swap is
  trivial since the button is centralized in one component.
- **Why the `<span>` wrapper:** Chrome and Safari suppress pointer events
  on `disabled` buttons, which suppresses the native `title` tooltip. The
  wrapping span carries the title and reliably fires the tooltip on hover.
- **Issue mentioned `EscrowPayFlow.tsx` as the relevant file** - that was
  inaccurate. The Description/Justification headers live in
  `app/hotel/[id]/escrow/[escrowId]/page.tsx` (BlockedStubView /
  ReleasedStubView). Verified by grep before touching anything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "PDF" button placeholder to escrow detail pages (feature coming soon).
  * Introduced "Escrow Description" section with editable field in escrow views.

* **Chores**
  * Enhanced backend infrastructure to support detailed escrow queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->