### PR TITLE
feat: add favorites page to fix 404 on sidebar heart icon click

### DIFF
--- a/apps/frontend/src/app/dashboard/favorites/page.tsx
+++ b/apps/frontend/src/app/dashboard/favorites/page.tsx
@@ -1,0 +1,28 @@
+import { Heart } from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Favorites | SafeTrust",
+};
+
+export default function FavoritesPage() {
+  return (
+    <div className="flex flex-col items-center justify-center py-24 gap-4">
+      <Heart className="h-12 w-12 text-muted-foreground" />
+      <p className="text-lg font-semibold text-foreground">
+        No saved apartments yet
+      </p>
+      <p className="text-sm text-muted-foreground">
+        Heart any apartment in{" "}
+        <Link
+          href="/dashboard/guest/suggestions"
+          className="text-orange-500 hover:underline"
+        >
+          Browse apartments
+        </Link>{" "}
+        to save it here.
+      </p>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/layouts/SideBar.tsx
+++ b/apps/frontend/src/components/layouts/SideBar.tsx
@@ -86,7 +86,7 @@ export function SideBar({
           </span>
         </Link>
         <Link
-          href="/favorites"
+          href="/dashboard/favorites"
           onClick={onClose}
           className="flex items-center gap-3 p-2 rounded-lg hover:bg-accent transition-colors duration-200 w-full group relative dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white"
         >


### PR DESCRIPTION
## Description

Clicking the Favorites heart icon in the sidebar navigated to `/favorites` which returned a 404 because no page or route existed at that path. This PR fixes it by:

1. Updating the sidebar link href from `/favorites` to `/dashboard/favorites` so the route resolves inside the dashboard layout.
2. Creating the missing `apps/frontend/src/app/dashboard/favorites/page.tsx` with an empty-state UI (heart icon, message, and a link to Browse apartments).

## Changes

- `apps/frontend/src/components/layouts/SideBar.tsx`: changed Favorite link `href` from `/favorites` to `/dashboard/favorites`
- `apps/frontend/src/app/dashboard/favorites/page.tsx`: new page with page title metadata and empty-state UI matching the dashboard layout

## Closes

Closes #192

## Notes

This is the MVP implementation — empty state only. Post-MVP persistence to a `user_favorites` Hasura table can be added as a follow-up once the schema is ready.

<img width="1710" height="956" alt="Captura de pantalla 2026-06-17 a la(s) 5 25 16 p  m" src="https://github.com/user-attachments/assets/4087035a-bd0c-4bc1-9728-15eb86541549" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a dedicated Favorites page in the dashboard where users can view and manage their saved apartments, complete with an empty state and convenient link to browse apartments.

* **Bug Fixes**
  * Corrected sidebar navigation link for the Favorites section to route to the updated page location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->