### PR TITLE
feat: build deposit-blocked escrow status view with tenant and owner …

### DIFF
--- a/apps/frontend/src/app/dashboard/escrow/[id]/page.tsx
+++ b/apps/frontend/src/app/dashboard/escrow/[id]/page.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { useQuery } from "@apollo/client";
+import { useParams, useRouter } from "next/navigation";
+import { Loader2, ArrowLeft } from "lucide-react";
+import type { CSSProperties } from "react";
+
+import {
+  GET_ESCROW_BY_ID,
+  GET_ESCROW_BLOCKED_VIEW,
+} from "@/graphql/queries/escrow-queries";
+import { InvoiceHeader } from "@/components/escrow/InvoiceHeader";
+import { ProcessStepper } from "@/components/escrow/ProcessStepper";
+import {
+  EscrowBlockedStatusView,
+  type EscrowBlockedData,
+} from "@/components/escrow/EscrowBlockedStatusView";
+import { Button } from "@/components/ui/button";
+
+// Map DB status → InvoiceHeader status type
+function toInvoiceStatus(
+  status: string
+): "pending" | "paid" | "blocked" | "released" {
+  switch (status) {
+    case "funded":
+      return "paid";
+    case "active":
+      return "blocked";
+    case "completed":
+      return "released";
+    default:
+      return "pending";
+  }
+}
+
+// Map DB status → ProcessStepper step
+function toStep(status: string): 1 | 2 | 3 | 4 {
+  switch (status) {
+    case "funded":
+      return 2;
+    case "active":
+      return 3;
+    case "completed":
+      return 4;
+    default:
+      return 1;
+  }
+}
+
+const styles = {
+  page: {
+    maxWidth: "72rem",
+    margin: "0 auto",
+    padding: "2rem 1.5rem 3rem",
+    color: "#111827",
+  } satisfies CSSProperties,
+  grid: {
+    display: "grid",
+    gap: "1.5rem",
+    marginTop: "1.5rem",
+    alignItems: "start",
+    gridTemplateColumns: "minmax(0, 2fr) minmax(18rem, 1fr)",
+  } satisfies CSSProperties,
+  panel: {
+    border: "1px solid #fed7aa",
+    borderRadius: "1rem",
+    backgroundColor: "#ffffff",
+    padding: "1.5rem",
+  } satisfies CSSProperties,
+  textarea: {
+    width: "100%",
+    border: "1px solid #d1d5db",
+    borderRadius: "0.75rem",
+    padding: "0.75rem",
+    font: "inherit",
+    resize: "vertical",
+    minHeight: "6rem",
+    boxSizing: "border-box",
+  } satisfies CSSProperties,
+} as const;
+
+// Shown for non-funded/active statuses — simple pending stub
+function PendingStub() {
+  return (
+    <p style={{ margin: 0, color: "#6b7280", fontSize: "0.95rem" }}>
+      Escrow is pending. Once funded the full status view will appear here.
+    </p>
+  );
+}
+
+export default function EscrowDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const id = params?.id as string;
+
+  // First fetch: get base escrow to know sender_address and status
+  const {
+    data: baseData,
+    loading: baseLoading,
+    error: baseError,
+  } = useQuery(GET_ESCROW_BY_ID, {
+    variables: { id },
+    skip: !id,
+  });
+
+  const escrow = baseData?.escrows_by_pk;
+  const isBlockedView =
+    escrow?.status === "active" || escrow?.status === "funded";
+
+  // Second fetch: only when status requires the blocked view (needs tenant lookup)
+  const {
+    data: blockedData,
+    loading: blockedLoading,
+    error: blockedError,
+  } = useQuery(GET_ESCROW_BLOCKED_VIEW, {
+    variables: { id, senderAddress: escrow?.sender_address ?? "" },
+    skip: !id || !isBlockedView || !escrow?.sender_address,
+  });
+
+  const loading = baseLoading || (isBlockedView && blockedLoading);
+  const error = baseError ?? blockedError;
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[40vh]">
+        <Loader2 className="h-7 w-7 animate-spin text-blue-500" />
+      </div>
+    );
+  }
+
+  if (error || !escrow) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[40vh] gap-4">
+        <p className="text-sm text-destructive">
+          {error
+            ? `Failed to load escrow — ${error.message}`
+            : "Escrow not found."}
+        </p>
+        <Button variant="outline" onClick={() => router.push("/dashboard/escrow")}>
+          Back to escrows
+        </Button>
+      </div>
+    );
+  }
+
+  const invoiceStatus = toInvoiceStatus(escrow.status);
+  const step = toStep(escrow.status);
+
+  // Build the data shape for EscrowBlockedStatusView
+  const blockedViewData: EscrowBlockedData | null =
+    isBlockedView && blockedData
+      ? {
+          createdAt: escrow.created_at,
+          amount: escrow.amount,
+          senderAddress: escrow.sender_address,
+          receiverAddress: escrow.receiver_address,
+          tenant: blockedData.users?.[0]
+            ? {
+                firstName: blockedData.users[0].first_name,
+                lastName: blockedData.users[0].last_name,
+                email: blockedData.users[0].email,
+              }
+            : null,
+          owner: escrow.apartment?.owner
+            ? {
+                firstName: escrow.apartment.owner.first_name,
+                lastName: escrow.apartment.owner.last_name,
+                email: escrow.apartment.owner.email,
+              }
+            : null,
+        }
+      : null;
+
+  const invoiceNumber = escrow.engagement_id ?? escrow.contract_id ?? escrow.id;
+  const paidAt = new Date(escrow.created_at).toLocaleDateString("en-US", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+
+  return (
+    <div style={styles.page}>
+      {/* Back nav */}
+      <button
+        type="button"
+        onClick={() => router.push("/dashboard/escrow")}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: "0.4rem",
+          background: "none",
+          border: "none",
+          color: "#6b7280",
+          fontSize: "0.875rem",
+          cursor: "pointer",
+          marginBottom: "1rem",
+          padding: 0,
+        }}
+      >
+        <ArrowLeft size={15} />
+        Back to escrows
+      </button>
+
+      <InvoiceHeader
+        invoiceNumber={invoiceNumber}
+        status={invoiceStatus}
+        paidAt={paidAt}
+      />
+
+      <div style={styles.grid}>
+        {/* Main content panel */}
+        <div style={styles.panel}>
+          <p
+            style={{
+              marginTop: 0,
+              marginBottom: "0.5rem",
+              fontSize: "0.8rem",
+              letterSpacing: "0.08em",
+              textTransform: "uppercase",
+              color: "#9ca3af",
+            }}
+          >
+            {escrow.apartment?.name ?? "Property"}
+          </p>
+          <h2
+            style={{ marginTop: 0, marginBottom: "1.5rem", fontSize: "1.5rem" }}
+          >
+            Payment batch - Escrow Status
+          </h2>
+
+          {/* Blocked / funded → real view with tenant + owner panels */}
+          {isBlockedView && blockedViewData && (
+            <EscrowBlockedStatusView data={blockedViewData} />
+          )}
+
+          {/* Loading the second query */}
+          {isBlockedView && !blockedViewData && (
+            <div className="flex items-center gap-2 text-muted-foreground text-sm py-4">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Loading tenant info…
+            </div>
+          )}
+
+          {/* Pending / other statuses */}
+          {!isBlockedView && <PendingStub />}
+        </div>
+
+        {/* Sidebar */}
+        <div style={{ display: "grid", gap: "1rem" }}>
+          <div style={styles.panel}>
+            <h3 style={{ marginTop: 0 }}>Notes</h3>
+            <textarea style={styles.textarea} placeholder="Notes..." />
+          </div>
+          <ProcessStepper currentStep={step} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/escrow/EscrowBlockedStatusView.tsx
+++ b/apps/frontend/src/components/escrow/EscrowBlockedStatusView.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import { PdfExportButton } from "@/components/escrow/PdfExportButton";
+
+// Truncate a wallet address in the style MJE...XN32
+function truncateAddress(address: string | null | undefined): string {
+  if (!address) return "—";
+  if (address.length <= 10) return address;
+  return `${address.slice(0, 4)}...${address.slice(-4)}`;
+}
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleDateString("en-US", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+const styles = {
+  panel: {
+    border: "1px solid #fed7aa",
+    borderRadius: "1rem",
+    backgroundColor: "#ffffff",
+    padding: "1.5rem",
+  } satisfies CSSProperties,
+  descriptionGrid: {
+    display: "grid",
+    gap: "1rem",
+    gridTemplateColumns: "repeat(auto-fit, minmax(12rem, 1fr))",
+    marginBottom: "1.5rem",
+  } satisfies CSSProperties,
+  infoGrid: {
+    display: "grid",
+    gap: "1.5rem",
+    gridTemplateColumns: "repeat(auto-fit, minmax(16rem, 1fr))",
+    borderTop: "1px solid #fed7aa",
+    paddingTop: "1.5rem",
+  } satisfies CSSProperties,
+  label: {
+    margin: 0,
+    color: "#6b7280",
+    fontSize: "0.85rem",
+  } satisfies CSSProperties,
+  value: {
+    margin: "0.35rem 0 0",
+    fontWeight: 600,
+  } satisfies CSSProperties,
+  monoValue: {
+    margin: "0.35rem 0 0",
+    fontWeight: 600,
+    fontFamily: "monospace",
+    fontSize: "0.9rem",
+  } satisfies CSSProperties,
+  panelHeadingRow: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: "1rem",
+    marginBottom: "1.25rem",
+    flexWrap: "wrap",
+  } satisfies CSSProperties,
+} as const;
+
+function InfoRow({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div>
+      <p style={styles.label}>{label}</p>
+      <p style={mono ? styles.monoValue : styles.value}>{value}</p>
+    </div>
+  );
+}
+
+export type EscrowBlockedData = {
+  createdAt: string | null | undefined;
+  amount: number | string | null | undefined;
+  senderAddress: string | null | undefined;
+  receiverAddress: string | null | undefined;
+  tenant: {
+    firstName: string | null | undefined;
+    lastName: string | null | undefined;
+    email: string | null | undefined;
+  } | null;
+  owner: {
+    firstName: string | null | undefined;
+    lastName: string | null | undefined;
+    email: string | null | undefined;
+  } | null;
+};
+
+export function EscrowBlockedStatusView({ data }: { data: EscrowBlockedData }) {
+  const depositAmount = data.amount != null
+    ? `$${Number(data.amount).toLocaleString()}`
+    : "—";
+
+  const tenantName = [data.tenant?.firstName, data.tenant?.lastName]
+    .filter(Boolean)
+    .join(" ") || "—";
+
+  const ownerName = [data.owner?.firstName, data.owner?.lastName]
+    .filter(Boolean)
+    .join(" ") || "—";
+
+  return (
+    <div style={{ display: "grid", gap: "1.5rem" }}>
+      {/* Escrow Description */}
+      <div>
+        <div style={styles.panelHeadingRow}>
+          <h3 style={{ margin: 0 }}>Escrow Description</h3>
+          <PdfExportButton />
+        </div>
+        <div style={styles.descriptionGrid}>
+          <InfoRow
+            label="Creation date"
+            value={formatDate(data.createdAt)}
+          />
+          <InfoRow
+            label="Amount blocked"
+            value={depositAmount}
+          />
+        </div>
+      </div>
+
+      {/* Tenant / Owner panels */}
+      <div style={styles.infoGrid}>
+        {/* Tenant Information */}
+        <div>
+          <h3 style={{ marginTop: 0, marginBottom: "1rem" }}>Tenant Information</h3>
+          <div style={{ display: "grid", gap: "0.75rem" }}>
+            <InfoRow label="Tenant name" value={tenantName} />
+            <InfoRow
+              label="Wallet Address"
+              value={truncateAddress(data.senderAddress)}
+              mono
+            />
+            <InfoRow
+              label="Email Address"
+              value={data.tenant?.email ?? "—"}
+            />
+            <InfoRow
+              label="Rental date"
+              value={formatDate(data.createdAt)}
+            />
+            <InfoRow label="Deposit amount" value={depositAmount} />
+          </div>
+        </div>
+
+        {/* Owner Information */}
+        <div>
+          <h3 style={{ marginTop: 0, marginBottom: "1rem" }}>Owner Information</h3>
+          <div style={{ display: "grid", gap: "0.75rem" }}>
+            <InfoRow label="Owner name" value={ownerName} />
+            <InfoRow
+              label="Wallet Address"
+              value={truncateAddress(data.receiverAddress)}
+              mono
+            />
+            <InfoRow
+              label="Email Address"
+              value={data.owner?.email ?? "—"}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/graphql/queries/escrow-queries.ts
+++ b/apps/frontend/src/graphql/queries/escrow-queries.ts
@@ -65,3 +65,39 @@ export const GET_ESCROW_BY_ID = gql`
     }
   }
 `;
+
+export const GET_ESCROW_BLOCKED_VIEW = gql`
+  query GetEscrowBlockedView($id: uuid!, $senderAddress: String!) {
+    escrows_by_pk(id: $id) {
+      id
+      contract_id
+      engagement_id
+      amount
+      status
+      created_at
+      sender_address
+      receiver_address
+      apartment {
+        id
+        name
+        owner {
+          id
+          first_name
+          last_name
+          email
+        }
+      }
+    }
+    users(
+      where: {
+        user_wallets: { wallet_address: { _eq: $senderAddress } }
+      }
+      limit: 1
+    ) {
+      id
+      first_name
+      last_name
+      email
+    }
+  }
+`;


### PR DESCRIPTION
## Summary

Implements the funded/active escrow detail view as described in #184.

## Changes

- **`GET_ESCROW_BLOCKED_VIEW` query** — fetches escrow by ID and simultaneously resolves the tenant user by matching `sender_address` against `user_wallets.wallet_address`
- **`EscrowBlockedStatusView` component** — Escrow Description section (creation date, amount blocked, disabled PDF export stub) + two side-by-side panels: Tenant Information and Owner Information (name, truncated wallet address, email, rental date, deposit amount)
- **`/dashboard/escrow/[id]` page** — dynamic route the existing escrow list already navigates to; fires the blocked-view query for `funded`/`active` statuses, maps DB status to `InvoiceHeader` badge and `ProcessStepper` step, falls back to a pending stub for other statuses

## What was tested

- `next lint` — ✔ No ESLint warnings or errors
- `tsc --noEmit` — zero errors in new files (5 pre-existing errors in unrelated files)

Closes #184


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added escrow detail page displaying comprehensive escrow information including status, creation date, and blocked amount.
  * Shows tenant and owner details on blocked escrow status view.
  * Includes loading indicators and error handling for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->