### PR TITLE
feat(hasura): add role-based select_permissions for escrows and apartments

### DIFF
--- a/infra/hasura/metadata/tenants/safetrust/databases/tables/public_apartments.yaml
+++ b/infra/hasura/metadata/tenants/safetrust/databases/tables/public_apartments.yaml
@@ -5,3 +5,48 @@ object_relationships:
   - name: owner
     using:
       foreign_key_constraint_on: owner_id
+select_permissions:
+  - role: tenant
+    permission:
+      columns:
+        - id
+        - owner_id
+        - name
+        - description
+        - price
+        - warranty_deposit
+        - coordinates
+        - address
+        - is_available
+        - available_from
+        - available_until
+        - image_urls
+        - created_at
+        - updated_at
+      filter:
+        _and:
+          - deleted_at:
+              _is_null: true
+          - is_available:
+              _eq: true
+  - role: landlord
+    permission:
+      columns:
+        - id
+        - owner_id
+        - name
+        - description
+        - price
+        - warranty_deposit
+        - coordinates
+        - address
+        - is_available
+        - available_from
+        - available_until
+        - image_urls
+        - created_at
+        - updated_at
+        - deleted_at
+      filter:
+        owner_id:
+          _eq: X-Hasura-User-Id

--- a/infra/hasura/metadata/tenants/safetrust/databases/tables/public_escrows.yaml
+++ b/infra/hasura/metadata/tenants/safetrust/databases/tables/public_escrows.yaml
@@ -31,7 +31,9 @@ select_permissions:
               - user_id:
                   _eq: X-Hasura-User-Id
               - wallet_address:
-                  _eq: sender_address
+                  _ceq:
+                    - "$"
+                    - sender_address
   - role: landlord
     permission:
       columns:
@@ -58,7 +60,9 @@ select_permissions:
                   - user_id:
                       _eq: X-Hasura-User-Id
                   - wallet_address:
-                      _eq: receiver_address
+                      _ceq:
+                        - "$"
+                        - receiver_address
           - _exists:
               _table:
                 name: apartments
@@ -66,6 +70,8 @@ select_permissions:
               _where:
                 _and:
                   - id:
-                      _eq: apartment_id
+                      _ceq:
+                        - "$"
+                        - apartment_id
                   - owner_id:
                       _eq: X-Hasura-User-Id

--- a/infra/hasura/metadata/tenants/safetrust/databases/tables/public_escrows.yaml
+++ b/infra/hasura/metadata/tenants/safetrust/databases/tables/public_escrows.yaml
@@ -5,3 +5,67 @@ object_relationships:
   - name: apartment
     using:
       foreign_key_constraint_on: apartment_id
+select_permissions:
+  - role: tenant
+    permission:
+      columns:
+        - id
+        - contract_id
+        - engagement_id
+        - property_id
+        - apartment_id
+        - sender_address
+        - receiver_address
+        - amount
+        - status
+        - unsigned_xdr
+        - created_at
+        - updated_at
+      filter:
+        _exists:
+          _table:
+            name: user_wallets
+            schema: public
+          _where:
+            _and:
+              - user_id:
+                  _eq: X-Hasura-User-Id
+              - wallet_address:
+                  _eq: sender_address
+  - role: landlord
+    permission:
+      columns:
+        - id
+        - contract_id
+        - engagement_id
+        - property_id
+        - apartment_id
+        - sender_address
+        - receiver_address
+        - amount
+        - status
+        - unsigned_xdr
+        - created_at
+        - updated_at
+      filter:
+        _or:
+          - _exists:
+              _table:
+                name: user_wallets
+                schema: public
+              _where:
+                _and:
+                  - user_id:
+                      _eq: X-Hasura-User-Id
+                  - wallet_address:
+                      _eq: receiver_address
+          - _exists:
+              _table:
+                name: apartments
+                schema: public
+              _where:
+                _and:
+                  - id:
+                      _eq: apartment_id
+                  - owner_id:
+                      _eq: X-Hasura-User-Id


### PR DESCRIPTION
Adds `select_permissions` for `tenant` and `landlord` roles on `apartments` and `escrows` tables in the Hasura metadata.

**Apartments**
- **Tenant** — sees all available, non-deleted listings (browse flow).
- **Landlord** — sees own listings including soft-deleted ones.

**Escrows**
- **Tenant** — sees escrows where their wallet matches `sender_address`.
- **Landlord** — sees escrows where their wallet matches `receiver_address`
  OR they own the apartment via `apartment_id → owner_id`.

Uses `_exists._table` to correlate wallet addresses through `user_wallets` without requiring a foreign key relationship.

**Blocked by** — replacement of `x-hasura-admin-secret` with JWT role claims in `apps/frontend/src/config/apollo.ts` (Batch N).

Closes #198


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented role-based data access controls for apartments and escrow records, enabling tenant and landlord users to view only relevant data based on their relationship to the properties and transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->