### PR TITLE
fix: wire BOOK button on guest dashboard to escrow create flow, restore missing TrustlessWork error modules

### DIFF
--- a/apps/frontend/src/components/dashboard/guest/GuestDashboard.tsx
+++ b/apps/frontend/src/components/dashboard/guest/GuestDashboard.tsx
@@ -242,14 +242,14 @@ export default function GuestDashboard() {
                           </span>
                         </div>
                       </div>
-
                       <div className="flex flex-col items-start md:items-end gap-2 shrink-0">
-                        <button
-                          type="button"
-                          className="rounded-lg bg-orange-500 px-10 py-3 text-sm font-bold text-white hover:bg-orange-600 transition-colors shadow-sm"
-                        >
-                          BOOK
-                        </button>
+                          <button
+                            type="button"
+                            onClick={() => router.push(`/hotel/${featured.id}/escrow/create`)}
+                            className="rounded-lg bg-orange-500 px-10 py-3 text-sm font-bold text-white hover:bg-orange-600 transition-colors shadow-sm"
+                          >
+                            BOOK
+                          </button>
                         <p className="text-xl font-bold text-emerald-600">
                           ${featured.price.toLocaleString()}.00{" "}
                           <span className="text-xs font-normal text-gray-400">Per month</span>

--- a/apps/frontend/src/lib/server/trustlesswork.ts
+++ b/apps/frontend/src/lib/server/trustlesswork.ts
@@ -1,0 +1,69 @@
+// Minimal server-side client for the TrustlessWork API.
+//
+// STATUS: stubbed for local/UI development. NEXT_PUBLIC_TRUSTLESS_WORK_API_KEY
+// is not set in most local environments yet (see TrustlessWorkProvider's
+// console warning on boot), so real requests would 401 anyway. This client
+// still makes a real HTTP call when the key IS configured; when it's not,
+// it throws a TrustlessWorkRequestError with a clear message instead of
+// silently faking a successful deploy.
+
+const TRUSTLESS_WORK_BASE_URL =
+  process.env.TRUSTLESS_WORK_API_URL ?? "https://api.trustlesswork.com";
+
+export class TrustlessWorkRequestError extends Error {
+  statusCode: number;
+  messages?: string[];
+  payload?: unknown;
+
+  constructor(message: string, statusCode: number, messages?: string[], payload?: unknown) {
+    super(message);
+    this.name = "TrustlessWorkRequestError";
+    this.statusCode = statusCode;
+    this.messages = messages;
+    this.payload = payload;
+  }
+}
+
+type TrustlessWorkRequestOptions = {
+  method?: "GET" | "POST" | "PUT" | "DELETE";
+  body?: unknown;
+};
+
+export async function trustlessWorkRequest<T>(
+  path: string,
+  options: TrustlessWorkRequestOptions = {},
+): Promise<T> {
+  const apiKey = process.env.TRUSTLESS_WORK_API_KEY ?? process.env.NEXT_PUBLIC_TRUSTLESS_WORK_API_KEY;
+
+  if (!apiKey) {
+    throw new TrustlessWorkRequestError(
+      "TrustlessWork API key is not configured. Set TRUSTLESS_WORK_API_KEY to enable real escrow deployment.",
+      401,
+      ["TrustlessWork API key is not configured."],
+    );
+  }
+
+  const response = await fetch(`${TRUSTLESS_WORK_BASE_URL}${path}`, {
+    method: options.method ?? "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: options.body ? JSON.stringify(options.body) : undefined,
+  });
+
+  const payload = await response.json().catch(() => null);
+
+  if (!response.ok) {
+    throw new TrustlessWorkRequestError(
+      payload && typeof payload === "object" && "message" in payload && typeof payload.message === "string"
+        ? payload.message
+        : `TrustlessWork request to ${path} failed with status ${response.status}.`,
+      response.status,
+      undefined,
+      payload,
+    );
+  }
+
+  return payload as T;
+}

--- a/apps/frontend/src/lib/server/trustlesswork.ts
+++ b/apps/frontend/src/lib/server/trustlesswork.ts
@@ -33,8 +33,8 @@ export async function trustlessWorkRequest<T>(
   path: string,
   options: TrustlessWorkRequestOptions = {},
 ): Promise<T> {
-  const apiKey = process.env.TRUSTLESS_WORK_API_KEY ?? process.env.NEXT_PUBLIC_TRUSTLESS_WORK_API_KEY;
-
+  //const apiKey = process.env.TRUSTLESS_WORK_API_KEY ?? process.env.NEXT_PUBLIC_TRUSTLESS_WORK_API_KEY;
+  const apiKey = process.env.TRUSTLESS_WORK_API_KEY
   if (!apiKey) {
     throw new TrustlessWorkRequestError(
       "TrustlessWork API key is not configured. Set TRUSTLESS_WORK_API_KEY to enable real escrow deployment.",
@@ -63,6 +63,14 @@ export async function trustlessWorkRequest<T>(
       undefined,
       payload,
     );
+  }
+
+  if (payload === null) {
+      throw new TrustlessWorkRequestError(
+          `TrustlessWork request to ${path} returned invalid JSON.`,
+          500,
+          ["Response body is not valid JSON."],
+        );
   }
 
   return payload as T;

--- a/apps/frontend/src/lib/trustlesswork-errors.ts
+++ b/apps/frontend/src/lib/trustlesswork-errors.ts
@@ -1,0 +1,49 @@
+// Normalizes errors from TrustlessWork API responses, fetch() failures, and
+// caught exceptions into a flat string array suitable for rendering in the UI.
+//
+// Consumers pass either:
+//   - a parsed JSON payload (e.g. { error, message, messages }) returned from
+//     our own API routes (/api/escrow/deploy, /helper/send-transaction), or
+//   - a caught `unknown` error from a try/catch block.
+
+type ErrorLikePayload = {
+  error?: unknown;
+  message?: unknown;
+  messages?: unknown;
+};
+
+function isErrorLikePayload(value: unknown): value is ErrorLikePayload {
+  return typeof value === "object" && value !== null;
+}
+
+export function getErrorMessages(source: unknown, fallback: string): string[] {
+  if (Array.isArray(source)) {
+    const messages = source.filter((item): item is string => typeof item === "string");
+    return messages.length > 0 ? messages : [fallback];
+  }
+
+  if (isErrorLikePayload(source)) {
+    if (Array.isArray(source.messages) && source.messages.length > 0) {
+      const messages = source.messages.filter((item): item is string => typeof item === "string");
+      if (messages.length > 0) return messages;
+    }
+
+    if (typeof source.error === "string" && source.error.trim()) {
+      return [source.error];
+    }
+
+    if (typeof source.message === "string" && source.message.trim()) {
+      return [source.message];
+    }
+  }
+
+  if (source instanceof Error && source.message) {
+    return [source.message];
+  }
+
+  if (typeof source === "string" && source.trim()) {
+    return [source];
+  }
+
+  return [fallback];
+}


### PR DESCRIPTION

---
### Description

This PR connects the **BOOK** button on the guest dashboard (`/dashboard/guest`) to the existing escrow booking flow, and restores two missing utility modules that prevented the destination page from compiling.

- issue related:  https://github.com/safetrustcr/dApp-SafeTrust/issues/176
- pull request related:  https://github.com/safetrustcr/dApp-SafeTrust/pull/210
### Type of Change

- [x] 🐛 Bug Fix
- [x] ♻️ Refactoring (none — pure addition/wiring, no existing logic changed)

### Current Behavior


- Clicking **BOOK** on the featured apartment card in `GuestDashboard.tsx` did nothing. The button had no `onClick` handler and no `href` — it was visually present but functionally dead.
- Separately, even when manually navigating to `/hotel/[id]/escrow/create`, the page failed to compile:
  ```
  Module not found: Can't resolve '@/lib/trustlesswork-errors'
  ```
  `EscrowPayFlow.tsx` and the `/api/escrow/deploy` and `/helper/send-transaction` routes import `getErrorMessages` from `@/lib/trustlesswork-errors` and `trustlessWorkRequest`/`TrustlessWorkRequestError` from `@/lib/server/trustlesswork` — neither file exists in `main`. This appears to predate this PR; the import was merged without the corresponding module ever being added.

### Results:
<img width="1354" height="720" alt="Screenshot from 2026-06-15 19-20-49" src="https://github.com/user-attachments/assets/5117901e-a6c9-462f-bc34-b70442f151a8" />

<img width="1360" height="715" alt="Screenshot from 2026-06-19 17-40-02" src="https://github.com/user-attachments/assets/f0057c36-8389-4fc7-848d-d7b59b3e272e" />



- Clicking **BOOK** navigates the user to `/hotel/[id]/escrow/create`, rendering the real apartment's property card (images, address, description) and the PAY flow, consistent with the already-working BOOK button on `/hotel/[id]/page.tsx`.
- `/hotel/[id]/escrow/create` compiles and renders without module-resolution errors.
- Clicking PAY without `TRUSTLESS_WORK_API_KEY` configured surfaces a clear, visible error message in the UI (via `EscrowPayFlow`'s error list) instead of crashing the page or failing silently.

### Changes

- **`apps/frontend/src/components/dashboard/guest/GuestDashboard.tsx`**
  Added `onClick={() => router.push(`/hotel/${featured.id}/escrow/create`)}` to the BOOK button. `useRouter()` and `featured.id` were already in scope — no new imports required.

- **`apps/frontend/src/lib/trustlesswork-errors.ts`** *(new)*
  Adds `getErrorMessages(source, fallback): string[]`, normalizing API error payloads (`{ error, message, messages }`), caught `Error` instances, and plain strings into a flat string array for UI display.

- **`apps/frontend/src/lib/server/trustlesswork.ts`** *(new)*
  Adds `trustlessWorkRequest<T>()` and `TrustlessWorkRequestError`, a minimal server-side TrustlessWork API client used by the deploy/send-transaction routes. When `TRUSTLESS_WORK_API_KEY` is unset (current state of all local/dev environments per `TrustlessWorkProvider`'s existing boot warning), it throws a clear `TrustlessWorkRequestError` rather than silently mocking a successful deploy.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Featured apartment booking button now navigates users directly to the escrow creation page, enabling the next step in the booking process.

* **Chores**
  * Added backend infrastructure and improved error handling for booking operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->