### PR TITLE
feat(hasura): add role-based select_permissions for escrows and apart…

### DIFF
--- a/infra/hasura/metadata/tenants/safetrust/databases/tables/public_apartments.yaml
+++ b/infra/hasura/metadata/tenants/safetrust/databases/tables/public_apartments.yaml
@@ -5,3 +5,54 @@ object_relationships:
   - name: owner
     using:
       foreign_key_constraint_on: owner_id
+select_permissions:
+  - role: tenant
+    permission:
+      # Tenants can browse all active, non-deleted listings.
+      # deleted_at is excluded from the column list — tenants never see deleted records.
+      columns:
+        - id
+        - owner_id
+        - name
+        - description
+        - price
+        - warranty_deposit
+        - coordinates
+        - location_area
+        - address
+        - is_available
+        - available_from
+        - available_until
+        - image_urls
+        - created_at
+        - updated_at
+      filter:
+        _and:
+          - is_available:
+              _eq: true
+          - deleted_at:
+              _is_null: true
+  - role: landlord
+    permission:
+      # Landlords see only their own apartments (all statuses, including soft-deleted,
+      # so they retain a history of removed listings).
+      columns:
+        - id
+        - owner_id
+        - name
+        - description
+        - price
+        - warranty_deposit
+        - coordinates
+        - location_area
+        - address
+        - is_available
+        - available_from
+        - available_until
+        - image_urls
+        - created_at
+        - updated_at
+        - deleted_at
+      filter:
+        owner_id:
+          _eq: X-Hasura-User-Id

--- a/infra/hasura/metadata/tenants/safetrust/databases/tables/public_escrows.yaml
+++ b/infra/hasura/metadata/tenants/safetrust/databases/tables/public_escrows.yaml
@@ -5,3 +5,50 @@ object_relationships:
   - name: apartment
     using:
       foreign_key_constraint_on: apartment_id
+select_permissions:
+  - role: tenant
+    permission:
+      # Tenants see escrows where they are the sender (their Stellar wallet).
+      # Requires X-Hasura-User-Wallet JWT claim (added in Batch N with the JWT migration).
+      # unsigned_xdr is included — the tenant must have it to sign the transaction.
+      # tenant_id is excluded — internal multitenancy discriminator, not user-facing.
+      columns:
+        - id
+        - contract_id
+        - engagement_id
+        - property_id
+        - sender_address
+        - receiver_address
+        - amount
+        - status
+        - unsigned_xdr
+        - apartment_id
+        - created_at
+        - updated_at
+      filter:
+        sender_address:
+          _eq: X-Hasura-User-Wallet
+  - role: landlord
+    permission:
+      # Landlords see escrows for apartments they own, resolved via the apartment
+      # object relationship (apartment.owner_id = X-Hasura-User-Id).
+      # Escrows without an apartment_id are not visible — all SafeTrust escrows
+      # must reference an apartment.
+      # unsigned_xdr is excluded — it is the tenant's signing artifact only.
+      # tenant_id is excluded — internal multitenancy discriminator, not user-facing.
+      columns:
+        - id
+        - contract_id
+        - engagement_id
+        - property_id
+        - sender_address
+        - receiver_address
+        - amount
+        - status
+        - apartment_id
+        - created_at
+        - updated_at
+      filter:
+        apartment:
+          owner_id:
+            _eq: X-Hasura-User-Id


### PR DESCRIPTION
## Summary

Closes #199

Adds `select_permissions` for `tenant` and `landlord` roles on `public.escrows` and `public.apartments`, following the patterns established in `public_users.yaml` and `public_user_wallets.yaml`.

## Decisions on open product questions

| Question | Decision |
|---|---|
| Can a tenant see all available apartments, or only those with an active bid/escrow? | All available listings, `is_available = true AND deleted_at IS NULL` |
| Does a landlord see escrows via `apartment.owner_id` or `receiver_address`? | Via `apartment.owner_id` relationship , works with existing `X-Hasura-User-Id` session variable, no new JWT claim needed |
| How are soft-deleted apartments exposed per role? | Tenants: completely hidden (filter + `deleted_at` excluded from column list). Landlords: visible in their own history (`deleted_at` included in columns, no filter on it) |

## Permission summary

### `public.apartments`
| Role | Filter | `deleted_at` visible? |
|---|---|---|
| `tenant` | `is_available = true AND deleted_at IS NULL` | No |
| `landlord` | `owner_id = X-Hasura-User-Id` | Yes (history) |

### `public.escrows`
| Role | Filter | `unsigned_xdr` visible? |
|---|---|---|
| `tenant` | `sender_address = X-Hasura-User-Wallet` | Yes (needed to sign the transaction) |
| `landlord` | `apartment.owner_id = X-Hasura-User-Id` | No (tenant's signing artifact only) |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined access controls for escrow records to adjust data field visibility based on user role permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->