### PR TITLE
Feat/build paid invoice view

### DIFF
--- a/apps/frontend/src/app/hotel/[id]/escrow/[escrowId]/layout.tsx
+++ b/apps/frontend/src/app/hotel/[id]/escrow/[escrowId]/layout.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, type ReactNode } from "react";
+
+import { Header } from "@/components/layouts/Header";
+
+export default function EscrowDetailLayout({ children }: { children: ReactNode }) {
+  useEffect(() => {
+    const html = document.documentElement;
+    const hadDark = html.classList.contains("dark");
+    html.classList.remove("dark");
+    html.classList.add("light");
+    return () => {
+      html.classList.remove("light");
+      if (hadDark) html.classList.add("dark");
+    };
+  }, []);
+
+  return (
+    <>
+      <Header />
+      {children}
+    </>
+  );
+}

--- a/apps/frontend/src/app/hotel/[id]/escrow/[escrowId]/page.tsx
+++ b/apps/frontend/src/app/hotel/[id]/escrow/[escrowId]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { InvoiceHeader } from '@/components/escrow/InvoiceHeader';
+import { PaidInvoiceView } from '@/components/escrow/PaidInvoiceView';
 import { PdfExportButton } from '@/components/escrow/PdfExportButton';
 import { ProcessStepper } from '@/components/escrow/ProcessStepper';
 import { useQuery } from '@apollo/client';
@@ -16,6 +17,10 @@ type ViewConfig = {
 };
 
 const styles = {
+  pageBg: {
+    backgroundColor: '#f3f4f6',
+    minHeight: '100vh',
+  } satisfies CSSProperties,
   page: {
     maxWidth: '72rem',
     margin: '0 auto',
@@ -25,14 +30,14 @@ const styles = {
   grid: {
     display: 'grid',
     gap: '1.5rem',
-    marginTop: '1.5rem',
+    marginTop: '0.5rem',
     alignItems: 'start',
   } satisfies CSSProperties,
   panel: {
-    border: '1px solid #fed7aa',
+    border: '1px solid #e5e7eb',
     borderRadius: '1rem',
     backgroundColor: '#ffffff',
-    padding: '1.5rem',
+    padding: '1.75rem',
   } satisfies CSSProperties,
   splitGrid: {
     display: 'grid',
@@ -82,7 +87,7 @@ function getEscrowViewConfig(status: EscrowStatus): ViewConfig {
     case 'pending_signature':
       return { label: 'paid', step: 1, title: 'Invoice Pending Signature' };
     case 'active':
-      return { label: 'paid', step: 2, title: 'Payment batch January 2025' };
+      return { label: 'paid', step: 2, title: '' };
     case 'funded':
       return { label: 'blocked', step: 3, title: 'Payment batch - Escrow Status' };
     case 'completed':
@@ -96,7 +101,7 @@ function formatDate(dateString?: string) {
   if (!dateString) return '';
   const d = new Date(dateString);
   if (isNaN(d.getTime())) return dateString;
-  return d.toLocaleDateString('en-US', {
+  return d.toLocaleDateString('en-GB', {
     day: 'numeric',
     month: 'short',
     year: 'numeric',
@@ -112,45 +117,22 @@ function InfoPair({ label, value }: { label: string; value: ReactNode }) {
   );
 }
 
-function PaidStubView() {
-  return (
-    <div style={{ display: 'grid', gap: '1.5rem' }}>
-      <div style={styles.splitGrid}>
-        <InfoPair label="Billed to" value="John_s@gmail.com" />
-        <InfoPair label="Invoice Number" value="INV4257-09-012" />
-        <InfoPair label="Billing details" value="John Smith" />
-        <InfoPair label="Currency" value="IDR - Dollar" />
-      </div>
-
-      <div style={{ border: '1px solid #fed7aa', borderRadius: '1rem', overflow: 'hidden' }}>
-        <table style={styles.table}>
-          <thead style={{ backgroundColor: '#fff7ed' }}>
-            <tr>
-              <th style={{ textAlign: 'left', padding: '0.9rem' }}>PRODUCT</th>
-              <th style={{ textAlign: 'right', padding: '0.9rem' }}>PRICE / MONTH</th>
-              <th style={{ textAlign: 'right', padding: '0.9rem' }}>DEPOSIT</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td style={{ padding: '0.9rem', borderTop: '1px solid #fed7aa' }}>La sabana apartment</td>
-              <td style={{ padding: '0.9rem', textAlign: 'right', borderTop: '1px solid #fed7aa' }}>
-                $4,000
-              </td>
-              <td style={{ padding: '0.9rem', textAlign: 'right', borderTop: '1px solid #fed7aa' }}>
-                $4,000
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-
-      <div style={{ fontSize: '0.95rem' }}>
-        <strong>Total: $8,000</strong>
-      </div>
-    </div>
-  );
-}
+const MOCK_PAID_ESCROW = {
+  id: 'mock-id',
+  engagement_id: 'INV4257-09-012',
+  contract_id: 'mock-contract',
+  amount: 4000,
+  created_at: '2025-01-20T12:00:00Z',
+  sender_address: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJKLMNOPQR',
+  apartment: {
+    id: 'mock-apartment',
+    name: 'La sabana apartment',
+    image_urls: ['/img/room1.png'],
+    price: 4000,
+    warranty_deposit: 4000,
+    available_until: '2025-01-30T12:00:00Z',
+  },
+};
 
 function BlockedStubView() {
   return (
@@ -306,55 +288,50 @@ export default function EscrowDetailPage({
   // If loading and we have no cached data, display a nice loading state
   if (loading && !escrow) {
     return (
-      <div style={styles.page}>
-        <div style={{ padding: '2rem', textAlign: 'center', color: '#6b7280' }}>
-          Loading escrow details...
+      <div style={styles.pageBg}>
+        <div style={styles.page}>
+          <div style={{ padding: '2rem', textAlign: 'center', color: '#6b7280' }}>
+            Loading escrow details...
+          </div>
         </div>
       </div>
     );
   }
 
   return (
-    <div style={styles.page}>
-      <InvoiceHeader
-        invoiceNumber={invoiceNumber}
-        status={status}
-        paidAt={paidAt}
-      />
+    <div style={styles.pageBg}>
+      <div style={styles.page}>
+        <InvoiceHeader
+          invoiceNumber={invoiceNumber}
+          status={status}
+          paidAt={paidAt}
+        />
 
-      <div style={{ ...styles.grid, gridTemplateColumns: 'minmax(0, 2fr) minmax(18rem, 1fr)' }}>
-        <div style={styles.panel}>
-          <p
-            style={{
-              marginTop: 0,
-              marginBottom: '0.5rem',
-              fontSize: '0.8rem',
-              letterSpacing: '0.08em',
-              textTransform: 'uppercase',
-              color: '#9ca3af',
-            }}
-          >
-            Hotel {params.id}
-          </p>
-          <h2 style={{ marginTop: 0, marginBottom: '1.5rem', fontSize: '1.5rem' }}>{view.title}</h2>
-
-          {view.label === 'paid' && <PaidStubView />}
-          {view.label === 'blocked' && <BlockedStubView />}
-          {view.label === 'released' && <ReleasedStubView />}
-        </div>
-
-        <div style={{ display: 'grid', gap: '1rem' }}>
+        <div style={{ ...styles.grid, gridTemplateColumns: 'minmax(0, 2fr) minmax(18rem, 1fr)' }}>
           <div style={styles.panel}>
-            <h3 style={{ marginTop: 0 }}>Notes</h3>
-            <textarea style={styles.input} placeholder="Notes..." />
-          </div>
-          <ProcessStepper currentStep={view.step} />
-        </div>
-      </div>
+            {view.title && (
+              <h2 style={{ marginTop: 0, marginBottom: '1.5rem', fontSize: '1.5rem' }}>{view.title}</h2>
+            )}
 
-      <p style={{ marginTop: '1rem', color: '#6b7280', fontSize: '0.85rem' }}>
-        Dev: append ?status=paid|blocked|released
-      </p>
+            {view.label === 'paid' && (
+              <PaidInvoiceView escrow={escrow ?? MOCK_PAID_ESCROW} />
+            )}
+            {view.label === 'blocked' && <BlockedStubView />}
+            {view.label === 'released' && <ReleasedStubView />}
+          </div>
+
+          <div style={styles.panel}>
+            <h3 style={{ marginTop: 0, marginBottom: '0.75rem', fontSize: '1.125rem', fontWeight: 700 }}>Notes</h3>
+            <textarea style={styles.input} placeholder="Notes..." />
+            <hr style={{ border: 'none', borderTop: '1px solid #e5e7eb', margin: '1.5rem 0' }} />
+            <ProcessStepper currentStep={view.step} />
+          </div>
+        </div>
+
+        <p style={{ marginTop: '1rem', color: '#6b7280', fontSize: '0.85rem' }}>
+          Dev: append ?status=paid|blocked|released
+        </p>
+      </div>
     </div>
   );
 }

--- a/apps/frontend/src/components/escrow/InvoiceHeader.tsx
+++ b/apps/frontend/src/components/escrow/InvoiceHeader.tsx
@@ -29,46 +29,20 @@ export function InvoiceHeader({
   return (
     <div
       style={{
-        display: 'flex',
-        flexWrap: 'wrap',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        gap: '1rem',
-        padding: '1.25rem 1.5rem',
-        borderRadius: '1rem',
-        border: '1px solid #fed7aa',
-        backgroundColor: '#ffffff',
+        padding: '0 0 1.25rem',
       }}
     >
-      <div>
-        <p
-          style={{
-            margin: 0,
-            fontSize: '0.8rem',
-            letterSpacing: '0.08em',
-            textTransform: 'uppercase',
-            color: '#9ca3af',
-          }}
-        >
-          Invoice number
-        </p>
-        <h1 style={{ margin: '0.35rem 0 0', fontSize: '1.75rem', fontWeight: 700 }}>{invoiceNumber}</h1>
-        {status !== 'pending_signature' && paidAt && (
-          <p style={{ margin: '0.25rem 0 0', fontSize: '0.875rem', color: '#6b7280' }}>
-            Paid at {paidAt}
-          </p>
-        )}
-      </div>
-
       <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', flexWrap: 'wrap' }}>
-        <EscrowStatusBadge status={status} className="px-3 py-1 text-sm font-bold" />
-        {paidAt && (
-          <div style={{ textAlign: 'right' }}>
-            <p style={{ margin: 0, fontSize: '0.8rem', color: '#9ca3af' }}>Updated</p>
-            <p style={{ margin: '0.25rem 0 0', fontWeight: 600 }}>{paidAt}</p>
-          </div>
-        )}
+        <h1 style={{ margin: 0, fontSize: '2rem', fontWeight: 800, color: '#111827', lineHeight: 1.1 }}>
+          {invoiceNumber}
+        </h1>
+        <EscrowStatusBadge status={status} className="px-4 py-1 text-sm font-bold" />
       </div>
+      {status !== 'pending_signature' && paidAt && (
+        <p style={{ margin: '0.5rem 0 0', fontSize: '0.8rem', color: '#6b7280' }}>
+          Paid at {paidAt}
+        </p>
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/components/escrow/PaidInvoiceView.tsx
+++ b/apps/frontend/src/components/escrow/PaidInvoiceView.tsx
@@ -1,0 +1,346 @@
+"use client";
+
+import { useQuery } from "@apollo/client";
+import type { CSSProperties, ReactNode } from "react";
+
+import { GET_USER_BY_WALLET_ADDRESS } from "@/graphql/queries/user-queries";
+import { truncateStellarAddress } from "@/lib/utils";
+
+const FALLBACK_IMAGE = "/img/room1.png";
+
+const TERMS_AND_CONDITIONS = `This rental agreement is governed by SafeTrust's escrow protocol on the Stellar network. The deposit is held in a smart contract and released to the property owner only upon mutual confirmation of move-out conditions. Tenants are responsible for property damage beyond normal wear and tear. Disputes are resolved through the SafeTrust arbitration process described in the platform terms of service.`;
+
+type ApartmentInput = {
+  id?: string;
+  name?: string | null;
+  image_urls?: string[] | null;
+  price?: number | null;
+  warranty_deposit?: number | null;
+  available_until?: string | null;
+};
+
+type EscrowInput = {
+  engagement_id?: string | null;
+  contract_id?: string | null;
+  id?: string;
+  amount?: number | null;
+  created_at?: string | null;
+  sender_address?: string | null;
+  apartment?: ApartmentInput | null;
+};
+
+type PaidInvoiceViewProps = {
+  escrow: EscrowInput;
+};
+
+const styles = {
+  container: {
+    display: "grid",
+    gap: "1.5rem",
+  } satisfies CSSProperties,
+  title: {
+    margin: 0,
+    fontSize: "1.5rem",
+    fontWeight: 700,
+    color: "#111827",
+  } satisfies CSSProperties,
+  divider: {
+    border: "none",
+    borderTop: "1px solid #e5e7eb",
+    margin: 0,
+  } satisfies CSSProperties,
+  infoGrid: {
+    display: "grid",
+    gap: "2rem",
+    gridTemplateColumns: "repeat(auto-fit, minmax(16rem, 1fr))",
+  } satisfies CSSProperties,
+  infoColumn: {
+    display: "grid",
+    gap: "0.9rem",
+  } satisfies CSSProperties,
+  infoRow: {
+    display: "grid",
+    gridTemplateColumns: "9rem 1fr",
+    gap: "0.75rem",
+    alignItems: "start",
+  } satisfies CSSProperties,
+  infoLabel: {
+    margin: 0,
+    color: "#6b7280",
+    fontSize: "0.9rem",
+  } satisfies CSSProperties,
+  infoValue: {
+    margin: 0,
+    fontWeight: 700,
+    color: "#111827",
+    fontSize: "0.95rem",
+  } satisfies CSSProperties,
+  tableWrap: {
+    borderRadius: "0.75rem",
+    overflow: "hidden",
+    border: "1px solid #e5e7eb",
+  } satisfies CSSProperties,
+  table: {
+    width: "100%",
+    borderCollapse: "collapse" as const,
+    fontSize: "0.95rem",
+  } satisfies CSSProperties,
+  th: {
+    textAlign: "left" as const,
+    padding: "0.85rem 1rem",
+    color: "#6b7280",
+    fontSize: "0.75rem",
+    letterSpacing: "0.06em",
+    backgroundColor: "#f9fafb",
+    fontWeight: 700,
+  } satisfies CSSProperties,
+  thRight: {
+    textAlign: "right" as const,
+    padding: "0.85rem 1rem",
+    color: "#6b7280",
+    fontSize: "0.75rem",
+    letterSpacing: "0.06em",
+    backgroundColor: "#f9fafb",
+    fontWeight: 700,
+  } satisfies CSSProperties,
+  td: {
+    padding: "1rem",
+    color: "#111827",
+    fontWeight: 600,
+  } satisfies CSSProperties,
+  tdRight: {
+    padding: "1rem",
+    textAlign: "right" as const,
+    color: "#111827",
+    fontWeight: 700,
+  } satisfies CSSProperties,
+  productCell: {
+    display: "flex",
+    alignItems: "center",
+    gap: "0.85rem",
+  } satisfies CSSProperties,
+  thumb: {
+    width: "3rem",
+    height: "3rem",
+    objectFit: "cover" as const,
+    borderRadius: "0.5rem",
+    display: "block",
+    flexShrink: 0,
+  } satisfies CSSProperties,
+  totalsGrid: {
+    display: "grid",
+    gridTemplateColumns: "minmax(0, 1fr) minmax(0, 1fr)",
+    gap: "0.5rem 2rem",
+    fontSize: "0.95rem",
+  } satisfies CSSProperties,
+  totalsRow: {
+    display: "grid",
+    gridTemplateColumns: "8rem 1fr",
+    gap: "0.75rem",
+    alignItems: "center",
+  } satisfies CSSProperties,
+  totalsLabel: {
+    margin: 0,
+    color: "#374151",
+    fontWeight: 600,
+  } satisfies CSSProperties,
+  totalsValue: {
+    margin: 0,
+    color: "#111827",
+    fontWeight: 700,
+  } satisfies CSSProperties,
+  termsTitle: {
+    margin: 0,
+    fontSize: "1rem",
+    fontWeight: 700,
+    color: "#111827",
+  } satisfies CSSProperties,
+  termsText: {
+    margin: "0.5rem 0 0",
+    color: "#6b7280",
+    fontSize: "0.875rem",
+    lineHeight: 1.55,
+  } satisfies CSSProperties,
+} as const;
+
+function formatLongDate(value?: string | null): string {
+  if (!value) return "-";
+  const d = new Date(value);
+  if (isNaN(d.getTime())) return "-";
+  return d.toLocaleDateString("en-US", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+function formatBatchMonth(value?: string | null): string {
+  if (!value) return "Payment batch";
+  const d = new Date(value);
+  if (isNaN(d.getTime())) return "Payment batch";
+  return `Payment batch ${d.toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+  })}`;
+}
+
+function formatCurrency(value: number | null | undefined): string {
+  if (value == null) return "-";
+  return value.toLocaleString("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  });
+}
+
+function computeDueDate(escrow: EscrowInput): string {
+  const fromApartment = escrow.apartment?.available_until;
+  if (fromApartment) return formatLongDate(fromApartment);
+  if (escrow.created_at) {
+    const d = new Date(escrow.created_at);
+    if (!isNaN(d.getTime())) {
+      d.setDate(d.getDate() + 30);
+      return formatLongDate(d.toISOString());
+    }
+  }
+  return "-";
+}
+
+function buildInvoiceNumber(escrow: EscrowInput): string {
+  const raw = escrow.engagement_id || escrow.contract_id || escrow.id || "";
+  if (!raw) return "-";
+  if (raw.startsWith("INV")) return raw;
+  return `INV-${raw.slice(0, 12)}`;
+}
+
+function buildTenantName(
+  firstName?: string | null,
+  lastName?: string | null,
+  fallbackAddress?: string | null,
+): string {
+  const combined = [firstName, lastName].filter(Boolean).join(" ").trim();
+  if (combined) return combined;
+  if (fallbackAddress) return truncateStellarAddress(fallbackAddress);
+  return "-";
+}
+
+function InfoRow({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div style={styles.infoRow}>
+      <p style={styles.infoLabel}>{label}</p>
+      <p style={styles.infoValue}>{value}</p>
+    </div>
+  );
+}
+
+export function PaidInvoiceView({ escrow }: PaidInvoiceViewProps) {
+  const senderAddress = escrow.sender_address ?? "";
+
+  const { data: userData } = useQuery(GET_USER_BY_WALLET_ADDRESS, {
+    variables: { wallet_address: senderAddress },
+    skip: !senderAddress,
+  });
+
+  const tenant = userData?.users?.[0];
+  const tenantName = buildTenantName(tenant?.first_name, tenant?.last_name, senderAddress);
+  const billedTo =
+    tenant?.email ??
+    (senderAddress ? truncateStellarAddress(senderAddress) : "-");
+
+  const apartmentName = escrow.apartment?.name ?? "-";
+  const apartmentThumb =
+    escrow.apartment?.image_urls?.[0] ?? FALLBACK_IMAGE;
+  const monthlyPrice = escrow.apartment?.price ?? null;
+  const deposit =
+    escrow.apartment?.warranty_deposit ?? escrow.amount ?? null;
+
+  const subtotal = monthlyPrice ?? 0;
+  const total = (monthlyPrice ?? 0) + (deposit ?? 0);
+
+  const invoiceNumber = buildInvoiceNumber(escrow);
+  const issued = formatLongDate(escrow.created_at);
+  const dueDate = computeDueDate(escrow);
+  const title = formatBatchMonth(escrow.created_at);
+
+  return (
+    <div style={styles.container}>
+      <h2 style={styles.title}>{title}</h2>
+      <hr style={styles.divider} />
+
+      <div style={styles.infoGrid}>
+        <div style={styles.infoColumn}>
+          <InfoRow label="Billed to" value={billedTo} />
+          <InfoRow label="Billing details" value={tenantName} />
+        </div>
+        <div style={styles.infoColumn}>
+          <InfoRow label="Invoice Number" value={invoiceNumber} />
+          <InfoRow label="Subject" value="Rent service" />
+          <InfoRow label="Currency" value="USDC - Dollar" />
+          <InfoRow label="Issued" value={issued} />
+          <InfoRow label="Due date" value={dueDate} />
+          <InfoRow label="Notes" value="-" />
+        </div>
+      </div>
+
+      <hr style={styles.divider} />
+
+      <div style={styles.tableWrap}>
+        <table style={styles.table}>
+          <thead>
+            <tr>
+              <th style={styles.th}>PRODUCT</th>
+              <th style={styles.thRight}>PRICE PER MONTH</th>
+              <th style={styles.thRight}>DEPOSIT</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td style={styles.td}>
+                <div style={styles.productCell}>
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={apartmentThumb}
+                    alt={apartmentName}
+                    style={styles.thumb}
+                    onError={(e) => {
+                      const img = e.target as HTMLImageElement;
+                      img.onerror = null;
+                      img.src = FALLBACK_IMAGE;
+                    }}
+                  />
+                  <span>{apartmentName}</span>
+                </div>
+              </td>
+              <td style={styles.tdRight}>{formatCurrency(monthlyPrice)}</td>
+              <td style={styles.tdRight}>{formatCurrency(deposit)}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <hr style={styles.divider} />
+
+      <div style={styles.totalsGrid}>
+        <div style={styles.totalsRow}>
+          <p style={styles.totalsLabel}>Subtotal</p>
+          <p style={styles.totalsValue}>{formatCurrency(subtotal)}</p>
+        </div>
+        <div style={styles.totalsRow}>
+          <p style={styles.totalsLabel}>Total</p>
+          <p style={styles.totalsValue}>{formatCurrency(total)}</p>
+        </div>
+        <div style={styles.totalsRow}>
+          <p style={styles.totalsLabel}>Discount (10%)</p>
+          <p style={styles.totalsValue}>-</p>
+        </div>
+      </div>
+
+      <hr style={styles.divider} />
+
+      <div>
+        <h3 style={styles.termsTitle}>Terms &amp; Condition</h3>
+        <p style={styles.termsText}>{TERMS_AND_CONDITIONS}</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/escrow/ProcessStepper.tsx
+++ b/apps/frontend/src/components/escrow/ProcessStepper.tsx
@@ -1,67 +1,95 @@
-// TODO: replace with real component once merged in frontend-SafeTrust
-// Source: frontend-SafeTrust/src/components/escrow/ProcessStepper.tsx
-
 import type { CSSProperties } from 'react';
+import { Home, CreditCard, Lock, Users, type LucideIcon } from 'lucide-react';
 
-const STEPS = [
-  { step: 1, title: 'Create escrow' },
-  { step: 2, title: 'Payment batch' },
-  { step: 3, title: 'Deposit blocked' },
-  { step: 4, title: 'Deposit released' },
-] as const;
+type Step = {
+  step: 1 | 2 | 3 | 4;
+  icon: LucideIcon;
+  description: string;
+};
+
+const STEPS: Step[] = [
+  {
+    step: 1,
+    icon: Home,
+    description:
+      'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+  },
+  {
+    step: 2,
+    icon: CreditCard,
+    description:
+      'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+  },
+  {
+    step: 3,
+    icon: Lock,
+    description:
+      'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+  },
+  {
+    step: 4,
+    icon: Users,
+    description:
+      'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+  },
+];
 
 export function ProcessStepper({ currentStep }: { currentStep: 1 | 2 | 3 | 4 }) {
   return (
-    <div
-      style={{
-        border: '1px solid #fed7aa',
-        borderRadius: '1rem',
-        backgroundColor: '#ffffff',
-        padding: '1.25rem',
-      }}
-    >
-      <h3 style={{ marginTop: 0, marginBottom: '1rem', fontSize: '1rem' }}>Process</h3>
-      <div style={{ display: 'grid', gap: '0.9rem' }}>
-        {STEPS.map(({ step, title }) => {
-          const isActive = step === currentStep;
-          const isComplete = step < currentStep;
-          const markerStyle: CSSProperties = isActive
-            ? { backgroundColor: '#22c55e', color: '#ffffff', border: '1px solid #22c55e' }
-            : isComplete
-              ? { backgroundColor: '#dcfce7', color: '#166534', border: '1px solid #86efac' }
-              : { backgroundColor: '#ffffff', color: '#9ca3af', border: '1px solid #d1d5db' };
+    <div>
+      <h3 style={{ margin: '0 0 1rem', fontSize: '1.125rem', fontWeight: 700, color: '#111827' }}>
+        Process
+      </h3>
+      <div style={{ position: 'relative', display: 'grid', gap: '1rem' }}>
+        {STEPS.map(({ step, icon: Icon, description }, idx) => {
+          const isActiveOrComplete = step <= currentStep;
+          const markerStyle: CSSProperties = isActiveOrComplete
+            ? { backgroundColor: '#22c55e', color: '#ffffff' }
+            : { backgroundColor: '#e5e7eb', color: '#9ca3af' };
+
+          const isLast = idx === STEPS.length - 1;
 
           return (
-            <div key={step} style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
-              <div
-                style={{
-                  ...markerStyle,
-                  width: '2rem',
-                  height: '2rem',
-                  borderRadius: '999px',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  fontWeight: 700,
-                  flexShrink: 0,
-                }}
-              >
-                {step}
-              </div>
-              <div>
-                <p
+            <div key={step} style={{ display: 'flex', alignItems: 'flex-start', gap: '0.75rem', position: 'relative' }}>
+              <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                <div
                   style={{
-                    margin: 0,
-                    fontWeight: isActive ? 700 : 600,
-                    color: isActive ? '#111827' : '#374151',
+                    ...markerStyle,
+                    width: '2.25rem',
+                    height: '2.25rem',
+                    borderRadius: '9999px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    flexShrink: 0,
                   }}
                 >
-                  {title}
-                </p>
-                <p style={{ margin: '0.2rem 0 0', color: '#9ca3af', fontSize: '0.8rem' }}>
-                  {isActive ? 'Current step' : isComplete ? 'Completed' : 'Pending'}
-                </p>
+                  <Icon size={18} />
+                </div>
+                {!isLast && (
+                  <div
+                    style={{
+                      width: '1px',
+                      flex: 1,
+                      minHeight: '1.25rem',
+                      backgroundColor: '#e5e7eb',
+                      marginTop: '0.25rem',
+                    }}
+                  />
+                )}
               </div>
+              <p
+                style={{
+                  margin: 0,
+                  paddingTop: '0.5rem',
+                  paddingBottom: isLast ? 0 : '1rem',
+                  color: '#6b7280',
+                  fontSize: '0.85rem',
+                  lineHeight: 1.45,
+                }}
+              >
+                {description}
+              </p>
             </div>
           );
         })}

--- a/apps/frontend/src/graphql/queries/user-queries.ts
+++ b/apps/frontend/src/graphql/queries/user-queries.ts
@@ -41,3 +41,19 @@ export const GET_USERS = gql`
     }
   }
 `;
+
+export const GET_USER_BY_WALLET_ADDRESS = gql`
+  query GetUserByWalletAddress($wallet_address: String!) {
+    users(
+      where: {
+        user_wallets: { wallet_address: { _eq: $wallet_address } }
+      }
+      limit: 1
+    ) {
+      id
+      email
+      first_name
+      last_name
+    }
+  }
+`;


### PR DESCRIPTION


  # [Pull Request](feat: build PaidInvoiceView with real escrow data and aligned detail page layout)

  ## Description
  Builds the **Paid Invoice View** that appears in the escrow detail page when `status = active` (post-PAY). The view
  replaces the previously hardcoded mock invoice with real data sourced from Hasura (escrow + apartment + tenant lookup by
  wallet address) and matches the design spec for the paid state. Adds the global SafeTrust Header (logo, search bar, user
  info) to the escrow detail route and forces light theme on this view to stay visually consistent with the design.

  - Issue related: https://github.com/safetrustcr/dApp-SafeTrust/issues/176

  ## Type of Change
  - [x] New feature (non-breaking change which adds functionality)
  - [x] Refactor (InvoiceHeader and ProcessStepper restructured to match the paid invoice design)

  ## Changes Made

  - **GraphQL Queries** (`apps/frontend/src/graphql/queries/user-queries.ts`)
    Added `GET_USER_BY_WALLET_ADDRESS` query that resolves a tenant (`first_name`, `last_name`, `email`) from a Stellar
  `wallet_address` via the `user_wallets` relation. Required because the existing escrow query joins `apartment.owner`
  (receiver) but not the sender/tenant.

  - **PaidInvoiceView component** *(new)* (`apps/frontend/src/components/escrow/PaidInvoiceView.tsx`)
    Renders the full invoice card:
    - **Billed to**: tenant email (fallback to truncated Stellar address)
    - **Billing details**: `first_name + last_name` (fallback to truncated address)
    - **Invoice Number**: derived from `escrow.engagement_id`
    - **Subject**: `Rent service`
    - **Currency**: `USDC - Dollar`
    - **Issued**: `escrow.created_at` formatted as locale long date
    - **Due date**: `escrow.apartment.available_until` (fallback: `created_at + 30 days`)
    - **Title**: dynamic `Payment batch {Month} {Year}` from `created_at`
    - **Product table**: apartment thumbnail + name, `apartment.price`, `apartment.warranty_deposit` (fallback
  `escrow.amount`)
    - **Totals**: Subtotal = price, Total = price + deposit
    - **Terms & Condition**: static SafeTrust escrow rental terms text
    All fields handle null/missing data gracefully with `-` fallbacks.

  - **InvoiceHeader refactor** (`apps/frontend/src/components/escrow/InvoiceHeader.tsx`)
    Removed the white card wrapper and orange border. Header now renders inline on the page gray background: invoice number
  + status badge side by side, with "Paid at {date}" below. Removed the redundant "Updated" column. Backward-compatible with
   the existing legacy `pending|paid|blocked|released` status props.

  - **ProcessStepper redesign** (`apps/frontend/src/components/escrow/ProcessStepper.tsx`)
    Replaced numbered circles with lifecycle icons from `lucide-react`: `Home` (Create) → `CreditCard` (Pay) → `Lock`
  (Block) → `Users` (Release). Steps ≤ `currentStep` render as solid green (active/complete); the rest as light gray
  (pending). Vertical connector line between markers. Description text per step.

  - **Escrow detail page integration** (`apps/frontend/src/app/hotel/[id]/escrow/[escrowId]/page.tsx`)
    - Wired `PaidInvoiceView` for `status === 'active'`.
    - Added `MOCK_PAID_ESCROW` so the dev-mode preview (`?status=paid`) renders the new component with realistic values
  instead of the old hardcoded stub.
    - Page background changed to `#f3f4f6`; panel borders changed from `#fed7aa` to `#e5e7eb`.
    - Removed the `Hotel {id}` uppercase label.
    - Merged the previously separate Notes panel and ProcessStepper into a single right-side card with a divider.
    - Date format switched from `en-US` (`Jan 25, 2025`) to `en-GB` (`25 Jan 2025`) to match the design.

  - **Escrow detail layout** *(new)* (`apps/frontend/src/app/hotel/[id]/escrow/[escrowId]/layout.tsx`)
    Adds the global `Header` (SafeTrust logo, search bar, notifications, user avatar) to the escrow detail route, which
  previously had no header. Force-applies the `light` class to `<html>` on mount and restores the previous theme on unmount,
   so users with dark mode preference still see the design as specified for this view without having their global preference
   modified.
<img width="1285" height="831" alt="Screenshot 2026-06-20 at 6 28 45 PM" src="https://github.com/user-attachments/assets/f08222a9-a9fc-4d8f-a04b-b86e427ebb62" />

  

  Closes #182 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added paid invoice view displaying invoice details, tenant information, and terms for paid escrows.

* **UI/UX Improvements**
  * Enhanced escrow detail page layout with reorganized two-panel design.
  * Simplified invoice header styling.
  * Improved process stepper with icon-based step indicators.
  * Automatic light mode display for escrow detail pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->