### PR TITLE
feat(rent): homologate Rent listing page and sidebar link from fronte…

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start --port 3001",
     "lint": "next lint",
+    "test": "vitest run",
     "codegen": "graphql-codegen --config codegen.ts"
   },
   "dependencies": {
@@ -44,6 +45,7 @@
     "react-day-picker": "^9.14.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.74.0",
+    "react-icons": "^5.5.0",
     "react-qr-code": "^2.0.18",
     "recharts": "^3.8.1",
     "server-only": "^0.0.1",
@@ -60,6 +62,7 @@
     "autoprefixer": "^10",
     "postcss": "^8",
     "tailwindcss": "^3",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^3.2.4"
   }
 }

--- a/apps/frontend/src/@types/hotel.ts
+++ b/apps/frontend/src/@types/hotel.ts
@@ -1,0 +1,31 @@
+export interface HotelAmenitySummary {
+  bedrooms: number;
+  bathrooms: number;
+  petFriendly: boolean;
+}
+
+export interface HotelOwner {
+  name: string;
+  avatar: string;
+}
+
+export interface HotelListing extends HotelAmenitySummary {
+  id: string;
+  name: string;
+  address: string;
+  price: number;
+  promoted: boolean;
+  images: string[];
+  category: 'Family' | 'Students' | 'Travelers';
+  location:
+    | 'San José'
+    | 'Heredia'
+    | 'Alajuela'
+    | 'Cartago'
+    | 'Puntarenas'
+    | 'Guanacaste'
+    | 'Limón';
+  owner: HotelOwner;
+  description: string;
+  favorite?: boolean;
+}

--- a/apps/frontend/src/@types/hotel.ts
+++ b/apps/frontend/src/@types/hotel.ts
@@ -15,7 +15,7 @@ export interface HotelListing extends HotelAmenitySummary {
   address: string;
   price: number;
   promoted: boolean;
-  images: string[];
+  images: [string, ...string[]];
   category: 'Family' | 'Students' | 'Travelers';
   location:
     | 'San José'
@@ -29,3 +29,6 @@ export interface HotelListing extends HotelAmenitySummary {
   description: string;
   favorite?: boolean;
 }
+
+export type HotelCategory = HotelListing['category'];
+export type HotelLocation = HotelListing['location'];

--- a/apps/frontend/src/app/rent/page.tsx
+++ b/apps/frontend/src/app/rent/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { HotelListing } from '@/@types/hotel';
+import type { HotelCategory, HotelListing, HotelLocation } from '@/@types/hotel';
 import {
   ApartmentGrid,
   BedroomTabs,
@@ -20,11 +20,11 @@ import { BsSortDownAlt } from 'react-icons/bs';
 
 export default function RentListingPage() {
   const router = useRouter();
-  const [selectedCategories, setSelectedCategories] = useState<string[]>([
+  const [selectedCategories, setSelectedCategories] = useState<HotelCategory[]>([
     'Family',
     'Students',
   ]);
-  const [selectedLocations, setSelectedLocations] = useState<string[]>([
+  const [selectedLocations, setSelectedLocations] = useState<HotelLocation[]>([
     'San José',
     'Heredia',
   ]);
@@ -57,6 +57,12 @@ export default function RentListingPage() {
     router.push(`/hotel/${apartment.id}`);
   };
 
+  const locationLabel =
+    selectedLocations.length > 0
+      ? `Costa Rica, ${selectedLocations.join(', ')}`
+      : 'Costa Rica';
+  const unitCount = filteredApartments.length;
+
   return (
     <div className="min-h-screen bg-white text-[#1c1c1c]">
       <HotelHeader />
@@ -82,9 +88,11 @@ export default function RentListingPage() {
             <div>
               <h1 className="text-[24px] leading-tight text-[#1d1d1d] sm:text-[30px]">
                 Available for rent in{' '}
-                <span className="font-semibold">Costa Rica, San José</span>
+                <span className="font-semibold">{locationLabel}</span>
               </h1>
-              <p className="mt-3 text-sm text-[#515151]">204 units available</p>
+              <p className="mt-3 text-sm text-[#515151]">
+                {unitCount} {unitCount === 1 ? 'unit' : 'units'} available
+              </p>
             </div>
 
             <div className="flex items-center gap-2 text-sm text-[#202020]">

--- a/apps/frontend/src/app/rent/page.tsx
+++ b/apps/frontend/src/app/rent/page.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import type { HotelListing } from '@/@types/hotel';
+import {
+  ApartmentGrid,
+  BedroomTabs,
+  FilterSidebar,
+  HotelHeader,
+} from '@/components/rent';
+// TODO: replace STUB_HOTELS with GET_ALL_APARTMENTS Hasura query (Batch N)
+import { STUB_HOTELS } from '@/lib/mockData/hotels';
+import {
+  filterRentListings,
+  toggleFilterValue,
+  type SortOption,
+} from '@/lib/rent/filterRentListings';
+import { useRouter } from 'next/navigation';
+import { useMemo, useState } from 'react';
+import { BsSortDownAlt } from 'react-icons/bs';
+
+export default function RentListingPage() {
+  const router = useRouter();
+  const [selectedCategories, setSelectedCategories] = useState<string[]>([
+    'Family',
+    'Students',
+  ]);
+  const [selectedLocations, setSelectedLocations] = useState<string[]>([
+    'San José',
+    'Heredia',
+  ]);
+  const [selectedBedrooms, setSelectedBedrooms] = useState('all');
+  const [sortOption] = useState<SortOption>('relevance');
+  const [minPrice, setMinPrice] = useState(3200);
+  const [maxPrice, setMaxPrice] = useState(206000);
+
+  const filteredApartments = useMemo(
+    () =>
+      filterRentListings(STUB_HOTELS, {
+        selectedCategories,
+        selectedLocations,
+        selectedBedrooms,
+        sortOption,
+        minPrice,
+        maxPrice,
+      }),
+    [
+      maxPrice,
+      minPrice,
+      selectedBedrooms,
+      selectedCategories,
+      selectedLocations,
+      sortOption,
+    ],
+  );
+
+  const handleApartmentClick = (apartment: HotelListing) => {
+    router.push(`/hotel/${apartment.id}`);
+  };
+
+  return (
+    <div className="min-h-screen bg-white text-[#1c1c1c]">
+      <HotelHeader />
+
+      <div className="mx-auto flex max-w-[1180px] flex-col lg:flex-row">
+        <FilterSidebar
+          selectedCategories={selectedCategories}
+          selectedLocations={selectedLocations}
+          minPrice={minPrice}
+          maxPrice={maxPrice}
+          onCategoryToggle={(category) =>
+            setSelectedCategories((current) => toggleFilterValue(current, category))
+          }
+          onLocationToggle={(location) =>
+            setSelectedLocations((current) => toggleFilterValue(current, location))
+          }
+          onMinPriceChange={setMinPrice}
+          onMaxPriceChange={setMaxPrice}
+        />
+
+        <main className="flex-1 px-6 py-8 lg:px-12">
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+            <div>
+              <h1 className="text-[24px] leading-tight text-[#1d1d1d] sm:text-[30px]">
+                Available for rent in{' '}
+                <span className="font-semibold">Costa Rica, San José</span>
+              </h1>
+              <p className="mt-3 text-sm text-[#515151]">204 units available</p>
+            </div>
+
+            <div className="flex items-center gap-2 text-sm text-[#202020]">
+              <BsSortDownAlt className="h-4 w-4" />
+              <span>Sort by:</span>
+              <span className="font-semibold text-[#ff6a00]">Relevance</span>
+            </div>
+          </div>
+
+          <div className="mt-6">
+            <BedroomTabs
+              selected={selectedBedrooms}
+              onSelect={setSelectedBedrooms}
+            />
+          </div>
+
+          <div className="mt-8">
+            <ApartmentGrid
+              apartments={filteredApartments}
+              onApartmentClick={handleApartmentClick}
+            />
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/layouts/SideBar.tsx
+++ b/apps/frontend/src/components/layouts/SideBar.tsx
@@ -6,7 +6,7 @@ import { LogoutButton } from "@/components/auth/LogoutButton";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 // Add to imports at the top:
-import { Bell, Heart, Home, LayoutDashboard, PlusSquare, Shield, Users } from "lucide-react";
+import { Bell, Building2, Heart, Home, LayoutDashboard, PlusSquare, Shield, Users } from "lucide-react";
 
 interface SideBarProps {
   className?: string;
@@ -66,6 +66,21 @@ export function SideBar({
           <span className="md:hidden lg:block">Escrow Dashboard</span>
           <span className="hidden md:group-hover:block lg:group-hover:hidden absolute left-14 bg-popover text-popover-foreground px-2 py-1 rounded shadow-md text-xs z-50 whitespace-nowrap">
             Escrow Dashboard
+          </span>
+        </Link>
+        <Link
+          href="/rent"
+          onClick={onClose}
+          className={cn(
+            "flex items-center gap-3 p-2 rounded-lg hover:bg-accent transition-colors duration-200 w-full group relative dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white",
+            pathname === "/rent" &&
+              "bg-accent font-medium dark:bg-gray-800 dark:text-white",
+          )}
+        >
+          <Building2 className="w-6 h-6 shrink-0 dark:text-gray-400" />
+          <span className="md:hidden lg:block">Rent</span>
+          <span className="hidden md:group-hover:block lg:group-hover:hidden absolute left-14 bg-popover text-popover-foreground px-2 py-1 rounded shadow-md text-xs z-50 whitespace-nowrap">
+            Rent
           </span>
         </Link>
         <Link

--- a/apps/frontend/src/components/rent/AmenityIcons.tsx
+++ b/apps/frontend/src/components/rent/AmenityIcons.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import type { HotelAmenitySummary } from '@/@types/hotel';
+import { FaBath, FaBed, FaPaw } from 'react-icons/fa';
+
+interface AmenityIconsProps extends HotelAmenitySummary {
+  compact?: boolean;
+}
+
+function AmenityPill({
+  icon,
+  label,
+  compact = false,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  compact?: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <span
+        className={`grid rounded-full bg-[#fff1e7] text-[#ff6a00] ${
+          compact ? 'h-6 w-6 place-items-center' : 'h-8 w-8 place-items-center'
+        }`}
+      >
+        {icon}
+      </span>
+      <span className={`${compact ? 'text-[11px]' : 'text-sm'} text-[#6b7280]`}>
+        {label}
+      </span>
+    </div>
+  );
+}
+
+export default function AmenityIcons({
+  bedrooms,
+  bathrooms,
+  petFriendly,
+  compact = false,
+}: AmenityIconsProps) {
+  return (
+    <div
+      className={`flex flex-wrap items-center gap-4 ${compact ? 'gap-3' : 'gap-5'}`}
+    >
+      <AmenityPill
+        compact={compact}
+        icon={<FaBed className={compact ? 'h-3.5 w-3.5' : 'h-4 w-4'} />}
+        label={`${bedrooms} bd.`}
+      />
+      <AmenityPill
+        compact={compact}
+        icon={<FaPaw className={compact ? 'h-3.5 w-3.5' : 'h-4 w-4'} />}
+        label={petFriendly ? 'pet friendly' : 'no pets'}
+      />
+      <AmenityPill
+        compact={compact}
+        icon={<FaBath className={compact ? 'h-3.5 w-3.5' : 'h-4 w-4'} />}
+        label={`${bathrooms} ba.`}
+      />
+    </div>
+  );
+}

--- a/apps/frontend/src/components/rent/AmenityIcons.tsx
+++ b/apps/frontend/src/components/rent/AmenityIcons.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { ReactNode } from 'react';
 import type { HotelAmenitySummary } from '@/@types/hotel';
 import { FaBath, FaBed, FaPaw } from 'react-icons/fa';
 
@@ -12,7 +13,7 @@ function AmenityPill({
   label,
   compact = false,
 }: {
-  icon: React.ReactNode;
+  icon: ReactNode;
   label: string;
   compact?: boolean;
 }) {

--- a/apps/frontend/src/components/rent/ApartmentCard.tsx
+++ b/apps/frontend/src/components/rent/ApartmentCard.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import type { HotelListing } from '@/@types/hotel';
+import { cn } from '@/lib/utils';
+import Image from 'next/image';
+import { AiOutlineHeart } from 'react-icons/ai';
+import { FaFireAlt } from 'react-icons/fa';
+import AmenityIcons from './AmenityIcons';
+import { formatListingPrice } from './formatListingPrice';
+
+interface ApartmentCardProps {
+  apartment: HotelListing;
+  onClick?: () => void;
+}
+
+export default function ApartmentCard({
+  apartment,
+  onClick,
+}: ApartmentCardProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group w-full overflow-hidden rounded-[16px] border border-[#e7e2dc] bg-white text-left transition hover:-translate-y-0.5 hover:shadow-[0_12px_30px_rgba(0,0,0,0.08)]"
+    >
+      <div className="relative">
+        <Image
+          src={apartment.images[0]}
+          alt={apartment.name}
+          width={420}
+          height={280}
+          className="h-[170px] w-full object-cover"
+        />
+        {apartment.promoted ? (
+          <span className="absolute bottom-0 left-0 inline-flex items-center gap-1 rounded-tr-[10px] bg-[#ff6a00] px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.02em] text-white">
+            <FaFireAlt className="h-3.5 w-3.5" />
+            Promoted
+          </span>
+        ) : null}
+      </div>
+
+      <div className="space-y-3 px-4 py-4">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-end gap-2">
+            <span className="text-[30px] font-semibold leading-none text-[#10a156]">
+              {formatListingPrice(apartment.price)}
+            </span>
+            <span className="pb-1 text-xs text-[#8b8b8b]">Per month</span>
+          </div>
+          <AiOutlineHeart
+            className={cn(
+              'h-5 w-5',
+              apartment.favorite
+                ? 'fill-[#ff2c2c] text-[#ff2c2c]'
+                : 'text-[#ff2c2c]'
+            )}
+          />
+        </div>
+
+        <div className="space-y-1">
+          <h3 className="text-base font-semibold text-[#222222]">
+            {apartment.name}
+          </h3>
+          <p className="line-clamp-1 text-xs text-[#8a8a8a]">
+            {apartment.address}
+          </p>
+        </div>
+
+        <AmenityIcons
+          bedrooms={apartment.bedrooms}
+          bathrooms={apartment.bathrooms}
+          petFriendly={apartment.petFriendly}
+          compact
+        />
+      </div>
+    </button>
+  );
+}

--- a/apps/frontend/src/components/rent/ApartmentDetail.tsx
+++ b/apps/frontend/src/components/rent/ApartmentDetail.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import type { HotelListing } from '@/@types/hotel';
+import Image from 'next/image';
+import { FaMapMarkerAlt } from 'react-icons/fa';
+import AmenityIcons from './AmenityIcons';
+import { formatListingPrice } from './formatListingPrice';
+import ImageGallery from './ImageGallery';
+
+interface ApartmentDetailProps {
+  apartment: HotelListing;
+  onBook: () => void;
+}
+
+export default function ApartmentDetail({
+  apartment,
+  onBook,
+}: ApartmentDetailProps) {
+  return (
+    <section className="flex-1 px-6 py-8 lg:px-10">
+      <ImageGallery
+        images={apartment.images}
+        promoted={apartment.promoted}
+        altText={apartment.name}
+      />
+
+      <div className="mt-8 flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+        <div className="flex-1">
+          <h1 className="text-[34px] font-semibold tracking-[-0.04em] text-[#181818]">
+            {apartment.name}
+          </h1>
+
+          <div className="mt-5 flex items-center gap-3 text-sm text-[#717171]">
+            <span className="grid h-8 w-8 place-items-center rounded-full bg-[#fff1e7] text-[#ff6a00]">
+              <FaMapMarkerAlt className="h-4 w-4" />
+            </span>
+            <span>{apartment.address}</span>
+          </div>
+
+          <div className="mt-8">
+            <AmenityIcons
+              bedrooms={apartment.bedrooms}
+              bathrooms={apartment.bathrooms}
+              petFriendly={apartment.petFriendly}
+            />
+          </div>
+        </div>
+
+        <div className="w-full rounded-[12px] lg:max-w-[210px]">
+          <button
+            type="button"
+            onClick={onBook}
+            className="w-full rounded-[8px] bg-[#ff6a00] px-6 py-4 text-xl font-semibold text-white transition hover:bg-[#ec6200]"
+          >
+            BOOK
+          </button>
+          <div className="mt-4 flex items-end gap-2">
+            <span className="text-[34px] font-semibold leading-none text-[#10a156]">
+              {formatListingPrice(apartment.price)}
+            </span>
+            <span className="pb-1 text-sm text-[#808080]">Per month</span>
+          </div>
+
+          <div className="mt-8 flex items-center justify-end gap-3">
+            <span className="text-sm font-medium text-[#5a5a5a]">
+              {apartment.owner.name}
+            </span>
+            <Image
+              src={apartment.owner.avatar}
+              alt={apartment.owner.name}
+              width={34}
+              height={34}
+              className="h-[34px] w-[34px] rounded-full object-cover"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-10 max-w-[760px]">
+        <h2 className="text-[22px] font-semibold text-[#1b1b1b]">
+          Apartment details
+        </h2>
+        <p className="mt-4 text-sm leading-6 text-[#6d6d6d]">
+          {apartment.description}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/src/components/rent/ApartmentGrid.tsx
+++ b/apps/frontend/src/components/rent/ApartmentGrid.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import type { HotelListing } from '@/@types/hotel';
+import ApartmentCard from './ApartmentCard';
+
+interface ApartmentGridProps {
+  apartments: HotelListing[];
+  onApartmentClick: (apartment: HotelListing) => void;
+}
+
+export default function ApartmentGrid({
+  apartments,
+  onApartmentClick,
+}: ApartmentGridProps) {
+  return (
+    <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
+      {apartments.map((apartment) => (
+        <ApartmentCard
+          key={apartment.id}
+          apartment={apartment}
+          onClick={() => onApartmentClick(apartment)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/rent/BedroomTabs.tsx
+++ b/apps/frontend/src/components/rent/BedroomTabs.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { BEDROOM_FILTERS } from '@/lib/mockData/hotels';
+
+interface BedroomTabsProps {
+  selected: string;
+  onSelect: (value: string) => void;
+}
+
+export default function BedroomTabs({ selected, onSelect }: BedroomTabsProps) {
+  return (
+    <div className="flex flex-wrap gap-3">
+      {BEDROOM_FILTERS.map((tab) => (
+        <button
+          key={tab.value}
+          type="button"
+          onClick={() => onSelect(tab.value)}
+          className={cn(
+            'rounded-[10px] border px-6 py-3 text-sm font-medium transition',
+            selected === tab.value
+              ? 'border-[#d9d9d9] bg-[#f7f4f0] text-[#333333]'
+              : 'border-[#e2e2e2] bg-white text-[#575757] hover:border-[#d0d0d0]'
+          )}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/rent/FilterSidebar.tsx
+++ b/apps/frontend/src/components/rent/FilterSidebar.tsx
@@ -126,7 +126,8 @@ export default function FilterSidebar({
             onChange={(event) =>
               onMinPriceChange(Math.min(Number(event.target.value), maxPrice))
             }
-            className="absolute inset-x-0 top-0 h-full w-full appearance-none bg-transparent opacity-0 cursor-pointer"
+            style={{ width: `${rightPercent}%` }}
+            className="absolute left-0 top-0 z-[3] h-full appearance-none bg-transparent opacity-0 cursor-pointer"
           />
           <input
             type="range"
@@ -137,7 +138,8 @@ export default function FilterSidebar({
             onChange={(event) =>
               onMaxPriceChange(Math.max(Number(event.target.value), minPrice))
             }
-            className="absolute inset-x-0 top-0 h-full w-full appearance-none bg-transparent opacity-0 cursor-pointer"
+            style={{ left: `${leftPercent}%`, width: `${100 - leftPercent}%` }}
+            className="absolute top-0 z-[4] h-full appearance-none bg-transparent opacity-0 cursor-pointer"
           />
         </div>
       </section>

--- a/apps/frontend/src/components/rent/FilterSidebar.tsx
+++ b/apps/frontend/src/components/rent/FilterSidebar.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { HOTEL_CATEGORIES, HOTEL_LOCATIONS } from '@/lib/mockData/hotels';
+import { formatListingPrice } from './formatListingPrice';
+
+interface FilterSidebarProps {
+  selectedCategories: string[];
+  selectedLocations: string[];
+  minPrice: number;
+  maxPrice: number;
+  onCategoryToggle: (category: string) => void;
+  onLocationToggle: (location: string) => void;
+  onMinPriceChange: (value: number) => void;
+  onMaxPriceChange: (value: number) => void;
+}
+
+const PRICE_BARS = [
+  { id: 'bar-1', height: 10 },
+  { id: 'bar-2', height: 18 },
+  { id: 'bar-3', height: 24 },
+  { id: 'bar-4', height: 20 },
+  { id: 'bar-5', height: 28 },
+  { id: 'bar-6', height: 16 },
+  { id: 'bar-7', height: 22 },
+  { id: 'bar-8', height: 14 },
+  { id: 'bar-9', height: 10 },
+  { id: 'bar-10', height: 26 },
+];
+
+function CheckboxRow({
+  checked,
+  label,
+  onChange,
+}: {
+  checked: boolean;
+  label: string;
+  onChange: () => void;
+}) {
+  return (
+    <label className="flex items-center gap-3 text-sm text-[#2f2f2f]">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={onChange}
+        className="h-4 w-4 rounded border-[#d8d8d8] text-[#ff6a00] focus:ring-[#ff6a00]"
+      />
+      {label}
+    </label>
+  );
+}
+
+export default function FilterSidebar({
+  selectedCategories,
+  selectedLocations,
+  minPrice,
+  maxPrice,
+  onCategoryToggle,
+  onLocationToggle,
+  onMinPriceChange,
+  onMaxPriceChange,
+}: FilterSidebarProps) {
+  const leftPercent = ((minPrice - 3200) / (206000 - 3200)) * 100;
+  const rightPercent = ((maxPrice - 3200) / (206000 - 3200)) * 100;
+
+  return (
+    <aside className="w-full border-b border-[#e8e1da] px-6 py-8 lg:w-[215px] lg:border-b-0 lg:border-r">
+      <section className="pb-8">
+        <h2 className="mb-5 text-[15px] font-semibold text-[#1d1d1d]">
+          Category
+        </h2>
+        <div className="space-y-3">
+          {HOTEL_CATEGORIES.map((category) => (
+            <CheckboxRow
+              key={category}
+              checked={selectedCategories.includes(category)}
+              label={category}
+              onChange={() => onCategoryToggle(category)}
+            />
+          ))}
+        </div>
+      </section>
+
+      <div className="my-0 h-px bg-[#ebe3dd]" />
+
+      <section className="py-8">
+        <h2 className="mb-3 text-[15px] font-semibold text-[#1d1d1d]">
+          Price Range
+        </h2>
+        <p className="mb-5 text-sm text-[#2f2f2f]">
+          {formatListingPrice(minPrice)} - {formatListingPrice(maxPrice)}
+        </p>
+
+        <div className="relative px-2 pb-3">
+          <div className="mb-4 flex h-10 items-end justify-between gap-1">
+            {PRICE_BARS.map((bar) => (
+              <span
+                key={bar.id}
+                className="w-full rounded-t-sm bg-[#ffbf93]"
+                style={{ height: `${bar.height}px` }}
+              />
+            ))}
+          </div>
+          <div className="relative h-1 rounded-full bg-[#ffd7bd]">
+            <div
+              className="absolute h-1 rounded-full bg-[#ff6a00]"
+              style={{
+                left: `${leftPercent}%`,
+                width: `${Math.max(rightPercent - leftPercent, 4)}%`,
+              }}
+            />
+            <span
+              className="absolute top-1/2 h-4 w-4 -translate-y-1/2 rounded-full border-2 border-white bg-[#ff6a00] shadow"
+              style={{ left: `calc(${leftPercent}% - 8px)` }}
+            />
+            <span
+              className="absolute top-1/2 h-4 w-4 -translate-y-1/2 rounded-full border-2 border-white bg-[#ff6a00] shadow"
+              style={{ left: `calc(${rightPercent}% - 8px)` }}
+            />
+          </div>
+          <input
+            type="range"
+            min={3200}
+            max={206000}
+            step={100}
+            value={minPrice}
+            onChange={(event) =>
+              onMinPriceChange(Math.min(Number(event.target.value), maxPrice))
+            }
+            className="absolute inset-x-0 top-0 h-full w-full appearance-none bg-transparent opacity-0 cursor-pointer"
+          />
+          <input
+            type="range"
+            min={3200}
+            max={206000}
+            step={100}
+            value={maxPrice}
+            onChange={(event) =>
+              onMaxPriceChange(Math.max(Number(event.target.value), minPrice))
+            }
+            className="absolute inset-x-0 top-0 h-full w-full appearance-none bg-transparent opacity-0 cursor-pointer"
+          />
+        </div>
+      </section>
+
+      <div className="my-0 h-px bg-[#ebe3dd]" />
+
+      <section className="pt-8">
+        <h2 className="mb-5 text-[15px] font-semibold text-[#1d1d1d]">
+          Location
+        </h2>
+        <div className="space-y-3">
+          {HOTEL_LOCATIONS.map((location) => (
+            <CheckboxRow
+              key={location}
+              checked={selectedLocations.includes(location)}
+              label={location}
+              onChange={() => onLocationToggle(location)}
+            />
+          ))}
+        </div>
+      </section>
+    </aside>
+  );
+}

--- a/apps/frontend/src/components/rent/HotelHeader.tsx
+++ b/apps/frontend/src/components/rent/HotelHeader.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import {
+  FaBell,
+  FaChevronDown,
+  FaRegUserCircle,
+  FaSearch,
+} from 'react-icons/fa';
+
+export default function HotelHeader() {
+  return (
+    <header className="border-b border-[#e8e1da] bg-white">
+      <div className="mx-auto flex max-w-[1180px] items-center gap-4 px-5 py-5 lg:px-7">
+        <Link href="/" className="flex items-center gap-3">
+          <Image src="/img/logo.png" alt="SafeTrust" width={36} height={36} />
+          <span className="text-[24px] font-semibold tracking-[-0.03em] text-[#202020]">
+            SafeTrust
+          </span>
+        </Link>
+
+        <div className="mx-auto hidden w-full max-w-[430px] items-center rounded-full border border-[#d9d9d9] bg-[#f3f3f3] px-2 py-1.5 md:flex">
+          <button
+            type="button"
+            className="flex items-center gap-2 rounded-full bg-white px-4 py-2 text-sm text-[#2d2d2d] shadow-sm"
+          >
+            Rent
+            <FaChevronDown className="h-3.5 w-3.5" />
+          </button>
+          <div className="mx-3 h-6 w-px bg-[#d2d2d2]" />
+          <span className="text-sm text-[#8a8a8a]">
+            City, province or neighborhood
+          </span>
+          <FaSearch className="ml-auto h-4 w-4 text-[#5c5c5c]" />
+        </div>
+
+        <div className="ml-auto flex items-center gap-5">
+          <div className="relative">
+            <FaBell className="h-4 w-4 text-[#1f1f1f]" />
+            <span className="absolute -right-1 -top-1 h-2 w-2 rounded-full bg-[#ff6a00]" />
+          </div>
+          <span className="hidden text-sm font-semibold text-[#1f1f1f] lg:block">
+            Randall Valenciano
+          </span>
+          <div className="grid h-10 w-10 place-items-center rounded-full border border-[#d9d9d9] bg-[#f6f6f6]">
+            <FaRegUserCircle className="h-5 w-5 text-[#1f1f1f]" />
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/apps/frontend/src/components/rent/HotelHeader.tsx
+++ b/apps/frontend/src/components/rent/HotelHeader.tsx
@@ -9,7 +9,15 @@ import {
   FaSearch,
 } from 'react-icons/fa';
 
-export default function HotelHeader() {
+export interface HotelHeaderProps {
+  userName?: string;
+  hasUnreadNotifications?: boolean;
+}
+
+export default function HotelHeader({
+  userName,
+  hasUnreadNotifications = false,
+}: HotelHeaderProps = {}) {
   return (
     <header className="border-b border-[#e8e1da] bg-white">
       <div className="mx-auto flex max-w-[1180px] items-center gap-4 px-5 py-5 lg:px-7">
@@ -38,11 +46,15 @@ export default function HotelHeader() {
         <div className="ml-auto flex items-center gap-5">
           <div className="relative">
             <FaBell className="h-4 w-4 text-[#1f1f1f]" />
-            <span className="absolute -right-1 -top-1 h-2 w-2 rounded-full bg-[#ff6a00]" />
+            {hasUnreadNotifications ? (
+              <span className="absolute -right-1 -top-1 h-2 w-2 rounded-full bg-[#ff6a00]" />
+            ) : null}
           </div>
-          <span className="hidden text-sm font-semibold text-[#1f1f1f] lg:block">
-            Randall Valenciano
-          </span>
+          {userName ? (
+            <span className="hidden text-sm font-semibold text-[#1f1f1f] lg:block">
+              {userName}
+            </span>
+          ) : null}
           <div className="grid h-10 w-10 place-items-center rounded-full border border-[#d9d9d9] bg-[#f6f6f6]">
             <FaRegUserCircle className="h-5 w-5 text-[#1f1f1f]" />
           </div>

--- a/apps/frontend/src/components/rent/ImageGallery.tsx
+++ b/apps/frontend/src/components/rent/ImageGallery.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Image from "next/image";
+import { cn } from "@/lib/utils";
+
+export interface ImageGalleryProps {
+  images: string[];
+  promoted?: boolean;
+  altText?: string;
+}
+
+/** Up to 3 indices for the right column: current hero first (for highlight), then others in gallery order. */
+function thumbIndices(activeIndex: number, length: number): number[] {
+  if (length <= 0) return [];
+  const ordered: number[] = [];
+  const push = (i: number) => {
+    if (i < 0 || i >= length) return;
+    if (!ordered.includes(i)) ordered.push(i);
+  };
+  push(activeIndex);
+  for (let i = 0; i < length; i++) push(i);
+  return ordered.slice(0, Math.min(3, length));
+}
+
+export default function ImageGallery({
+  images,
+  promoted = false,
+  altText = "Apartment",
+}: ImageGalleryProps) {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const safeLen = images.length;
+  const heroIndex = safeLen === 0 ? 0 : Math.min(Math.max(0, activeIndex), safeLen - 1);
+  const heroSrc = images[heroIndex];
+  const thumbs = useMemo(() => thumbIndices(heroIndex, safeLen), [heroIndex, safeLen]);
+
+  useEffect(() => {
+    if (safeLen === 0) return;
+    setActiveIndex((i) => Math.max(0, Math.min(i, safeLen - 1)));
+  }, [safeLen]);
+
+  if (safeLen === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex w-full min-w-0 flex-col gap-4 md:flex-row md:items-stretch md:gap-4">
+      {/* Hero — 2/3 on md+ */}
+      <div className="relative min-h-[220px] w-full min-w-0 overflow-hidden rounded-lg md:w-2/3 md:flex-[2] md:min-h-[320px] lg:min-h-[360px]">
+        <Image
+          src={heroSrc}
+          alt={`${altText} — main photo (${heroIndex + 1} of ${safeLen})`}
+          fill
+          className="object-cover"
+          sizes="(max-width: 768px) 100vw, 66vw"
+          priority
+        />
+        {promoted ? (
+          <span className="absolute bottom-3 left-3 flex items-center gap-1 rounded bg-orange-500 px-2 py-1 text-xs font-bold text-white">
+            🏷️ PROMOTED
+          </span>
+        ) : null}
+      </div>
+
+      {/* Thumbnails — 1/3 on md+, stacked; mobile: full width, stacked under hero */}
+      {safeLen > 1 ? (
+        <div
+          className="flex w-full flex-shrink-0 flex-col gap-2 md:w-1/3 md:flex-[1]"
+          role="list"
+          aria-label="Gallery thumbnails"
+        >
+          {thumbs.map((imageIndex) => {
+            const src = images[imageIndex]!;
+            const isActive = imageIndex === heroIndex;
+            return (
+              <button
+                key={`${imageIndex}-${src}`}
+                type="button"
+                role="listitem"
+                aria-label={`Show photo ${imageIndex + 1} of ${safeLen}`}
+                aria-current={isActive ? "true" : undefined}
+                onClick={() => setActiveIndex(imageIndex)}
+                className={cn(
+                  "relative aspect-[4/3] w-full min-h-[88px] shrink-0 overflow-hidden rounded-lg border-2 border-transparent outline-none transition-shadow md:min-h-[96px] lg:min-h-[108px]",
+                  isActive
+                    ? "ring-2 ring-orange-500 ring-offset-2 ring-offset-background"
+                    : "hover:opacity-90 focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2",
+                )}
+              >
+                <Image
+                  src={src}
+                  alt={`${altText} — photo ${imageIndex + 1} of ${safeLen}`}
+                  fill
+                  className="object-cover"
+                  sizes="(max-width: 768px) 100vw, 34vw"
+                />
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/rent/ImageGallery.tsx
+++ b/apps/frontend/src/components/rent/ImageGallery.tsx
@@ -65,40 +65,39 @@ export default function ImageGallery({
 
       {/* Thumbnails — 1/3 on md+, stacked; mobile: full width, stacked under hero */}
       {safeLen > 1 ? (
-        <div
+        <ul
           className="flex w-full flex-shrink-0 flex-col gap-2 md:w-1/3 md:flex-[1]"
-          role="list"
           aria-label="Gallery thumbnails"
         >
           {thumbs.map((imageIndex) => {
             const src = images[imageIndex]!;
             const isActive = imageIndex === heroIndex;
             return (
-              <button
-                key={`${imageIndex}-${src}`}
-                type="button"
-                role="listitem"
-                aria-label={`Show photo ${imageIndex + 1} of ${safeLen}`}
-                aria-current={isActive ? "true" : undefined}
-                onClick={() => setActiveIndex(imageIndex)}
-                className={cn(
-                  "relative aspect-[4/3] w-full min-h-[88px] shrink-0 overflow-hidden rounded-lg border-2 border-transparent outline-none transition-shadow md:min-h-[96px] lg:min-h-[108px]",
-                  isActive
-                    ? "ring-2 ring-orange-500 ring-offset-2 ring-offset-background"
-                    : "hover:opacity-90 focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2",
-                )}
-              >
-                <Image
-                  src={src}
-                  alt={`${altText} — photo ${imageIndex + 1} of ${safeLen}`}
-                  fill
-                  className="object-cover"
-                  sizes="(max-width: 768px) 100vw, 34vw"
-                />
-              </button>
+              <li key={`${imageIndex}-${src}`}>
+                <button
+                  type="button"
+                  aria-label={`Show photo ${imageIndex + 1} of ${safeLen}`}
+                  aria-current={isActive ? "true" : undefined}
+                  onClick={() => setActiveIndex(imageIndex)}
+                  className={cn(
+                    "relative aspect-[4/3] w-full min-h-[88px] shrink-0 overflow-hidden rounded-lg border-2 border-transparent outline-none transition-shadow md:min-h-[96px] lg:min-h-[108px]",
+                    isActive
+                      ? "ring-2 ring-orange-500 ring-offset-2 ring-offset-background"
+                      : "hover:opacity-90 focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2",
+                  )}
+                >
+                  <Image
+                    src={src}
+                    alt={`${altText} — photo ${imageIndex + 1} of ${safeLen}`}
+                    fill
+                    className="object-cover"
+                    sizes="(max-width: 768px) 100vw, 34vw"
+                  />
+                </button>
+              </li>
             );
           })}
-        </div>
+        </ul>
       ) : null}
     </div>
   );

--- a/apps/frontend/src/components/rent/SuggestionCard.tsx
+++ b/apps/frontend/src/components/rent/SuggestionCard.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { Heart } from 'lucide-react';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { formatListingPrice } from './formatListingPrice';
+
+export interface SuggestionCardProps {
+  id: string;
+  name: string;
+  address: string;
+  price: number;
+  bedrooms: number;
+  bathrooms: number;
+  petFriendly: boolean;
+  image?: string;
+  isLiked?: boolean;
+  onLike?: (id: string) => void;
+  onClick?: (id: string) => void;
+}
+
+export default function SuggestionCard({
+  id,
+  name,
+  address,
+  price,
+  bedrooms,
+  bathrooms,
+  petFriendly,
+  image,
+  isLiked = false,
+  onLike,
+  onClick,
+}: SuggestionCardProps) {
+  const router = useRouter();
+  const [liked, setLiked] = useState(isLiked);
+
+  useEffect(() => {
+    setLiked(isLiked);
+  }, [isLiked]);
+
+  const handleCardClick = () => {
+    if (onClick) {
+      onClick(id);
+      return;
+    }
+
+    router.push(`/hotel/${id}`);
+  };
+
+  const handleLikeClick = () => {
+    setLiked((currentLiked) => !currentLiked);
+    onLike?.(id);
+  };
+
+  return (
+    <div
+      className={cn(
+        'group w-full rounded-[12px] border border-[#dfd9d2] bg-white p-3 shadow-sm transition',
+        'hover:border-[#cfc6bc] hover:shadow-md'
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <button
+          type="button"
+          onClick={handleCardClick}
+          aria-label={`View ${name}`}
+          className="flex min-w-0 flex-1 items-start gap-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#10a156]/30"
+        >
+          <div className="relative h-[60px] w-[60px] shrink-0 overflow-hidden rounded-[10px] bg-muted">
+            <Image
+              src={image ?? '/img/hotel/hotel1.jpg'}
+              alt={name}
+              fill
+              sizes="60px"
+              className="object-cover"
+            />
+          </div>
+
+          <div className="min-w-0 flex-1">
+            <div className="min-w-0">
+              <h3 className="text-base font-medium leading-5 text-foreground">
+                {name}
+              </h3>
+              <p className="mt-1 line-clamp-2 text-sm leading-5 text-muted-foreground">
+                {address}
+              </p>
+            </div>
+
+            <div className="mt-3 flex items-end justify-between gap-3">
+              <p className="text-xs text-muted-foreground">
+                {bedrooms}bd · {petFriendly ? 'pet friendly' : 'no pets'} ·{' '}
+                {bathrooms} ba
+              </p>
+              <span className="text-right text-[1.75rem] font-semibold leading-none text-green-600">
+                {formatListingPrice(price)}
+              </span>
+            </div>
+          </div>
+        </button>
+
+        <button
+          type="button"
+          onClick={handleLikeClick}
+          aria-pressed={liked}
+          aria-label={liked ? `Unlike ${name}` : `Like ${name}`}
+          className="mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-red-500 transition hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-200"
+        >
+          <Heart
+            aria-hidden="true"
+            className={cn(
+              'h-5 w-5 transition-colors',
+              liked ? 'fill-red-500 text-red-500' : 'text-red-500'
+            )}
+          />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/rent/SuggestionsList.tsx
+++ b/apps/frontend/src/components/rent/SuggestionsList.tsx
@@ -27,10 +27,16 @@ export default function SuggestionsList({
   }, [apartments]);
 
   const handleLike = (id: string) => {
-    setLikedById((currentLikes) => ({
-      ...currentLikes,
-      [id]: !currentLikes[id],
-    }));
+    setLikedById((currentLikes) => {
+      const apartment = apartments.find((item) => item.id === id);
+      const current =
+        currentLikes[id] ?? apartment?.favorite ?? false;
+
+      return {
+        ...currentLikes,
+        [id]: !current,
+      };
+    });
   };
 
   return (

--- a/apps/frontend/src/components/rent/SuggestionsList.tsx
+++ b/apps/frontend/src/components/rent/SuggestionsList.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import type { HotelListing } from '@/@types/hotel';
+import { useEffect, useState } from 'react';
+import SuggestionCard from './SuggestionCard';
+
+interface SuggestionsListProps {
+  apartments: HotelListing[];
+  onSelect?: (id: string) => void;
+}
+
+export default function SuggestionsList({
+  apartments,
+  onSelect,
+}: SuggestionsListProps) {
+  const [likedById, setLikedById] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    setLikedById((currentLikes) =>
+      Object.fromEntries(
+        apartments.map((apartment) => [
+          apartment.id,
+          currentLikes[apartment.id] ?? apartment.favorite ?? false,
+        ])
+      )
+    );
+  }, [apartments]);
+
+  const handleLike = (id: string) => {
+    setLikedById((currentLikes) => ({
+      ...currentLikes,
+      [id]: !currentLikes[id],
+    }));
+  };
+
+  return (
+    <aside className="w-full border-b border-[#e8e1da] px-6 py-8 lg:w-[320px] lg:border-b-0 lg:border-r">
+      <div className="mb-6">
+        <h2 className="text-[28px] font-semibold tracking-[-0.03em] text-[#181818]">
+          Suggestions
+        </h2>
+        <p className="mt-4 text-sm text-[#202020]">
+          More than 200 units available
+        </p>
+      </div>
+
+      <div className="space-y-4">
+        {apartments.slice(0, 5).map((apartment) => (
+          <SuggestionCard
+            key={apartment.id}
+            id={apartment.id}
+            name={apartment.name}
+            address={apartment.address}
+            price={apartment.price}
+            bedrooms={apartment.bedrooms}
+            bathrooms={apartment.bathrooms}
+            petFriendly={apartment.petFriendly}
+            image={apartment.images[0]}
+            isLiked={likedById[apartment.id] ?? apartment.favorite ?? false}
+            onLike={handleLike}
+            onClick={onSelect}
+          />
+        ))}
+      </div>
+    </aside>
+  );
+}

--- a/apps/frontend/src/components/rent/formatListingPrice.ts
+++ b/apps/frontend/src/components/rent/formatListingPrice.ts
@@ -1,0 +1,8 @@
+const listingPriceFormatter = new Intl.NumberFormat('de-DE', {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0,
+});
+
+export function formatListingPrice(price: number) {
+  return `$${listingPriceFormatter.format(price)}`;
+}

--- a/apps/frontend/src/components/rent/index.ts
+++ b/apps/frontend/src/components/rent/index.ts
@@ -1,0 +1,11 @@
+export { default as HotelHeader } from './HotelHeader';
+export { default as ApartmentCard } from './ApartmentCard';
+export { default as ApartmentGrid } from './ApartmentGrid';
+export { default as FilterSidebar } from './FilterSidebar';
+export { default as BedroomTabs } from './BedroomTabs';
+export { default as ApartmentDetail } from './ApartmentDetail';
+export { default as ImageGallery } from './ImageGallery';
+export { default as SuggestionCard } from './SuggestionCard';
+export { default as SuggestionsList } from './SuggestionsList';
+export { default as AmenityIcons } from './AmenityIcons';
+export * from './types';

--- a/apps/frontend/src/components/rent/types.ts
+++ b/apps/frontend/src/components/rent/types.ts
@@ -1,0 +1,82 @@
+export interface Booking {
+  id: string;
+  guestName: string;
+  guestEmail: string;
+  checkInDate: string;
+  checkOutDate: string;
+  roomNumber?: string;
+  status: 'pending' | 'checked_in' | 'checked_out' | 'completed' | 'cancelled';
+}
+
+export interface CheckInData {
+  roomNumber: string;
+  checkInTime: string;
+  wifiPassword?: string;
+  signature?: string;
+  staffMember?: string;
+}
+
+export interface CheckOutData {
+  checkOutTime: string;
+  staffMember?: string;
+  roomCondition?: 'excellent' | 'good' | 'fair' | 'poor';
+}
+
+export interface DamageAssessment {
+  hasDamage: boolean;
+  condition: 'excellent' | 'good' | 'fair' | 'poor';
+  description?: string;
+  damagePhotos?: string[];
+}
+
+export interface MilestoneApprovalData {
+  contractId: string;
+  milestoneId: string;
+  bookingId: string;
+  timestamp: string;
+}
+
+export interface MilestoneStatusData {
+  contractId: string;
+  milestoneId: string;
+  newStatus: string;
+  bookingId: string;
+  timestamp: string;
+}
+
+export interface EscrowMetadata {
+  bookingId: string;
+  hotelName: string;
+  checkInDate: string;
+  checkOutDate: string;
+  guestName?: string;
+  guestEmail?: string;
+  roomNumber?: string;
+  checkInTime?: string;
+  checkOutTime?: string;
+  staffApprover?: string;
+  hasDamage?: boolean;
+  damageDescription?: string;
+}
+
+export interface CheckInApprovalProps {
+  booking: Booking;
+  escrow: {
+    contractId: string;
+    milestoneId?: string;
+    metadata?: EscrowMetadata;
+  };
+  onSuccess?: (data: MilestoneApprovalData) => void;
+  onError?: (error: Error) => void;
+}
+
+export interface CheckOutProcessProps {
+  booking: Booking;
+  escrow: {
+    contractId: string;
+    milestoneId?: string;
+    metadata?: EscrowMetadata;
+  };
+  onSuccess?: (data: MilestoneStatusData) => void;
+  onError?: (error: Error) => void;
+}

--- a/apps/frontend/src/components/rent/types.ts
+++ b/apps/frontend/src/components/rent/types.ts
@@ -1,3 +1,10 @@
+export type BookingStatus =
+  | 'pending'
+  | 'checked_in'
+  | 'checked_out'
+  | 'completed'
+  | 'cancelled';
+
 export interface Booking {
   id: string;
   guestName: string;
@@ -5,7 +12,7 @@ export interface Booking {
   checkInDate: string;
   checkOutDate: string;
   roomNumber?: string;
-  status: 'pending' | 'checked_in' | 'checked_out' | 'completed' | 'cancelled';
+  status: BookingStatus;
 }
 
 export interface CheckInData {
@@ -39,7 +46,7 @@ export interface MilestoneApprovalData {
 export interface MilestoneStatusData {
   contractId: string;
   milestoneId: string;
-  newStatus: string;
+  newStatus: BookingStatus;
   bookingId: string;
   timestamp: string;
 }

--- a/apps/frontend/src/lib/mockData/apartments.ts
+++ b/apps/frontend/src/lib/mockData/apartments.ts
@@ -1,0 +1,138 @@
+export interface Apartment {
+  id: string;
+  name: string;
+  description?: string | null;
+  price: number;
+  warranty_deposit: number;
+  is_available: boolean;
+  image_urls?: string[] | null;
+  address: {
+    street?: string;
+    neighborhood?: string;
+    city?: string;
+    country?: string;
+  };
+  available_from: string;
+  available_until?: string | null;
+  created_at: string;
+  owner_id: string;
+}
+
+export const MOCK_APARTMENTS: Apartment[] = [
+  {
+    id: '1',
+    name: 'La Sabana Sur Studio',
+    description: 'Modern studio with ocean view, fully furnished.',
+    price: 1200,
+    warranty_deposit: 2400,
+    is_available: true,
+    image_urls: ['/img/room1.png'],
+    address: {
+      street: 'Calle 42, Avenida 8',
+      neighborhood: 'Sabana Norte',
+      city: 'San José',
+      country: 'Costa Rica',
+    },
+    available_from: '2026-06-01T00:00:00Z',
+    available_until: null,
+    created_at: '2026-05-20T10:00:00Z',
+    owner_id: 'mock-owner-1',
+  },
+  {
+    id: '2',
+    name: 'Los Yoses Apartment',
+    description: 'Pet friendly, 2 bedrooms, near university.',
+    price: 950,
+    warranty_deposit: 1900,
+    is_available: true,
+    image_urls: ['/img/room2.png'],
+    address: {
+      street: '329 Calle Santos',
+      neighborhood: 'Los Yoses',
+      city: 'San José',
+      country: 'Costa Rica',
+    },
+    available_from: '2026-06-15T00:00:00Z',
+    available_until: null,
+    created_at: '2026-05-18T08:30:00Z',
+    owner_id: 'mock-owner-1',
+  },
+  {
+    id: '3',
+    name: 'Heredia Garden House',
+    description: 'Spacious house with garden, 3 bedrooms.',
+    price: 1500,
+    warranty_deposit: 3000,
+    is_available: false,
+    image_urls: ['/img/hotel/hotel1.jpg'],
+    address: {
+      street: 'Avenida Central',
+      neighborhood: 'Centro',
+      city: 'Heredia',
+      country: 'Costa Rica',
+    },
+    available_from: '2026-07-01T00:00:00Z',
+    available_until: '2026-12-31T00:00:00Z',
+    created_at: '2026-05-10T14:00:00Z',
+    owner_id: 'mock-owner-1',
+  },
+  {
+    id: '4',
+    name: 'Curridabat Loft',
+    description: 'Compact loft, perfect for students.',
+    price: 700,
+    warranty_deposit: 1400,
+    is_available: true,
+    image_urls: [],
+    address: {
+      street: 'Calle 15',
+      neighborhood: 'Curridabat',
+      city: 'San José',
+      country: 'Costa Rica',
+    },
+    available_from: '2026-06-10T00:00:00Z',
+    available_until: null,
+    created_at: '2026-05-05T09:00:00Z',
+    owner_id: 'mock-owner-1',
+  },
+  {
+    id: '5',
+    name: 'Escazú Penthouse',
+    description: 'Luxury penthouse with city views and pool access.',
+    price: 2200,
+    warranty_deposit: 4400,
+    is_available: true,
+    image_urls: ['/img/buildings.png'],
+    address: {
+      street: 'Plaza Itskatzu',
+      neighborhood: 'Escazú',
+      city: 'San José',
+      country: 'Costa Rica',
+    },
+    available_from: '2026-06-20T00:00:00Z',
+    available_until: null,
+    created_at: '2026-05-01T11:00:00Z',
+    owner_id: 'mock-owner-1',
+  },
+  {
+    id: '6',
+    name: 'Alajuela Family Home',
+    description: 'Pet friendly, 4 bedrooms, near the airport.',
+    price: 1100,
+    warranty_deposit: 2200,
+    is_available: false,
+    image_urls: [],
+    address: {
+      street: 'Calle Real',
+      neighborhood: 'Centro',
+      city: 'Alajuela',
+      country: 'Costa Rica',
+    },
+    available_from: '2026-08-01T00:00:00Z',
+    available_until: null,
+    created_at: '2026-04-28T16:45:00Z',
+    owner_id: 'mock-owner-1',
+  },
+];
+
+export const MOCK_AGGREGATE_COUNT = MOCK_APARTMENTS.length;

--- a/apps/frontend/src/lib/mockData/apartments.ts
+++ b/apps/frontend/src/lib/mockData/apartments.ts
@@ -1,3 +1,12 @@
+/**
+ * Hasura/dashboard apartment shape. The /rent listing UI uses {@link HotelListing}
+ * from `@/@types/hotel` via `STUB_HOTELS`; map between these at the data layer
+ * when Hasura wiring lands.
+ */
+import type { HotelListing } from '@/@types/hotel';
+
+export type { HotelListing };
+
 export interface Apartment {
   id: string;
   name: string;

--- a/apps/frontend/src/lib/mockData/hotels.ts
+++ b/apps/frontend/src/lib/mockData/hotels.ts
@@ -1,0 +1,163 @@
+import type { HotelListing } from '@/@types/hotel';
+
+export const STUB_HOTELS: HotelListing[] = [
+  {
+    id: '1',
+    name: 'La sabana sur',
+    address: '329 Calle santos, paseo colón, San José',
+    price: 4058,
+    bedrooms: 2,
+    bathrooms: 1,
+    petFriendly: true,
+    promoted: true,
+    images: [
+      '/img/hotel/hotel1.jpg',
+      '/img/hotel/hotel1.jpg',
+      '/img/hotel/hotel1.jpg',
+      '/img/hotel/hotel1.jpg',
+    ],
+    category: 'Family',
+    location: 'San José',
+    owner: { name: 'Alberto Casas', avatar: '/img/person.png' },
+    description:
+      'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry’s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.',
+    favorite: false,
+  },
+  {
+    id: '2',
+    name: 'Los yoses',
+    address: '329 Calle santos, paseo colón, San José',
+    price: 4000,
+    bedrooms: 2,
+    bathrooms: 1,
+    petFriendly: true,
+    promoted: false,
+    images: [
+      '/img/hotel/hotel1.jpg',
+      '/img/hotel/hotel1.jpg',
+      '/img/hotel/hotel1.jpg',
+      '/img/hotel/hotel1.jpg',
+    ],
+    category: 'Students',
+    location: 'San José',
+    owner: { name: 'Alberto Casas', avatar: '/img/person.png' },
+    description:
+      'Compact apartment near key routes with bright interiors and fast access to the city center.',
+    favorite: false,
+  },
+  {
+    id: '3',
+    name: 'Paseo Colón Loft',
+    address: '225 Avenida central, paseo colón, San José',
+    price: 3980,
+    bedrooms: 1,
+    bathrooms: 1,
+    petFriendly: false,
+    promoted: false,
+    images: [
+      '/img/hotel/hotel1.jpg',
+      '/img/hotel/hotel1.jpg',
+      '/img/hotel/hotel1.jpg',
+      '/img/hotel/hotel1.jpg',
+    ],
+    category: 'Travelers',
+    location: 'San José',
+    owner: { name: 'Randall Valenciano', avatar: '/img/person.png' },
+    description:
+      'Loft-style living with clean finishes, natural light, and walkable access to major amenities.',
+    favorite: true,
+  },
+  {
+    id: '4',
+    name: 'Heredia Central',
+    address: '101 Calle norte, Heredia centro, Heredia',
+    price: 4120,
+    bedrooms: 3,
+    bathrooms: 2,
+    petFriendly: true,
+    promoted: true,
+    images: [
+      '/img/hotel/hotel1.jpg',
+      '/img/hotel/hotel1.jpg',
+      '/img/hotel/hotel1.jpg',
+      '/img/hotel/hotel1.jpg',
+    ],
+    category: 'Family',
+    location: 'Heredia',
+    owner: { name: 'María López', avatar: '/img/person.png' },
+    description:
+      'Larger family-ready floor plan with flexible living space and strong natural ventilation.',
+    favorite: false,
+  },
+  {
+    id: '5',
+    name: 'Alajuela Heights',
+    address: '78 Ruta 3, Alajuela, Alajuela',
+    price: 3895,
+    bedrooms: 2,
+    bathrooms: 1,
+    petFriendly: false,
+    promoted: false,
+    images: [
+      '/img/hotel/hotel1.jpg',
+      '/img/hotel/hotel1.jpg',
+      '/img/hotel/hotel1.jpg',
+      '/img/hotel/hotel1.jpg',
+    ],
+    category: 'Travelers',
+    location: 'Alajuela',
+    owner: { name: 'Luis Salas', avatar: '/img/person.png' },
+    description:
+      'Quiet rental with a warm palette, ideal for medium stays and airport-adjacent access.',
+    favorite: true,
+  },
+  {
+    id: '6',
+    name: 'Cartago View',
+    address: '54 Vista real, Cartago, Cartago',
+    price: 4215,
+    bedrooms: 3,
+    bathrooms: 2,
+    petFriendly: true,
+    promoted: false,
+    images: [
+      '/img/hotel/hotel1.jpg',
+      '/img/hotel/hotel1.jpg',
+      '/img/hotel/hotel1.jpg',
+      '/img/hotel/hotel1.jpg',
+    ],
+    category: 'Students',
+    location: 'Cartago',
+    owner: { name: 'Ana Ruiz', avatar: '/img/person.png' },
+    description:
+      'Balanced shared-living layout with comfortable bedrooms and a practical amenity mix.',
+    favorite: false,
+  },
+];
+
+export const HOTEL_CATEGORIES = ['Family', 'Students', 'Travelers'] as const;
+
+export const HOTEL_LOCATIONS = [
+  'San José',
+  'Heredia',
+  'Alajuela',
+  'Cartago',
+  'Puntarenas',
+  'Guanacaste',
+  'Limón',
+] as const;
+
+export const BEDROOM_FILTERS = [
+  { label: 'All apartments', value: 'all' },
+  { label: '1 bedroom', value: '1' },
+  { label: '2 bedrooms', value: '2' },
+  { label: '3 bedrooms', value: '3' },
+] as const;
+
+export function getHotelById(id: string) {
+  return STUB_HOTELS.find((hotel) => hotel.id === id) ?? STUB_HOTELS[0];
+}
+
+export function getSuggestedHotels(activeId: string) {
+  return STUB_HOTELS.filter((hotel) => hotel.id !== activeId).slice(0, 5);
+}

--- a/apps/frontend/src/lib/mockData/hotels.ts
+++ b/apps/frontend/src/lib/mockData/hotels.ts
@@ -154,8 +154,8 @@ export const BEDROOM_FILTERS = [
   { label: '3 bedrooms', value: '3' },
 ] as const;
 
-export function getHotelById(id: string) {
-  return STUB_HOTELS.find((hotel) => hotel.id === id) ?? STUB_HOTELS[0];
+export function getHotelById(id: string): HotelListing | undefined {
+  return STUB_HOTELS.find((hotel) => hotel.id === id);
 }
 
 export function getSuggestedHotels(activeId: string) {

--- a/apps/frontend/src/lib/rent/filterRentListings.test.ts
+++ b/apps/frontend/src/lib/rent/filterRentListings.test.ts
@@ -1,6 +1,57 @@
+import type { HotelListing } from '@/@types/hotel';
 import { describe, expect, it } from 'vitest';
-import { STUB_HOTELS } from '@/lib/mockData/hotels';
 import { filterRentListings, toggleFilterValue } from './filterRentListings';
+
+const TEST_LISTINGS: HotelListing[] = [
+  {
+    id: 'a',
+    name: 'Promoted family home',
+    address: '1 Main St, San José',
+    price: 4050,
+    bedrooms: 2,
+    bathrooms: 1,
+    petFriendly: true,
+    promoted: true,
+    images: ['/img/hotel/hotel1.jpg'],
+    category: 'Family',
+    location: 'San José',
+    owner: { name: 'Owner A', avatar: '/img/person.png' },
+    description: 'Test listing A',
+    favorite: false,
+  },
+  {
+    id: 'b',
+    name: 'Student flat',
+    address: '2 Oak Ave, Heredia',
+    price: 3900,
+    bedrooms: 1,
+    bathrooms: 1,
+    petFriendly: false,
+    promoted: false,
+    images: ['/img/hotel/hotel1.jpg'],
+    category: 'Students',
+    location: 'Heredia',
+    owner: { name: 'Owner B', avatar: '/img/person.png' },
+    description: 'Test listing B',
+    favorite: true,
+  },
+  {
+    id: 'c',
+    name: 'Traveler studio',
+    address: '3 Pine Rd, Alajuela',
+    price: 4200,
+    bedrooms: 3,
+    bathrooms: 2,
+    petFriendly: true,
+    promoted: false,
+    images: ['/img/hotel/hotel1.jpg'],
+    category: 'Travelers',
+    location: 'Alajuela',
+    owner: { name: 'Owner C', avatar: '/img/person.png' },
+    description: 'Test listing C',
+    favorite: false,
+  },
+];
 
 describe('toggleFilterValue', () => {
   it('adds and removes values from the filter set', () => {
@@ -16,7 +67,7 @@ describe('toggleFilterValue', () => {
 
 describe('filterRentListings', () => {
   it('filters by category, location, bedrooms, and price', () => {
-    const results = filterRentListings(STUB_HOTELS, {
+    const results = filterRentListings(TEST_LISTINGS, {
       selectedCategories: ['Family'],
       selectedLocations: ['San José'],
       selectedBedrooms: '2',
@@ -26,19 +77,20 @@ describe('filterRentListings', () => {
     });
 
     expect(results).toHaveLength(1);
-    expect(results[0]?.id).toBe('1');
+    expect(results[0]?.id).toBe('a');
   });
 
   it('sorts promoted listings first when using relevance', () => {
-    const results = filterRentListings(STUB_HOTELS, {
+    const results = filterRentListings(TEST_LISTINGS, {
       selectedCategories: [],
       selectedLocations: [],
       selectedBedrooms: 'all',
       sortOption: 'relevance',
-      minPrice: 3200,
-      maxPrice: 206000,
+      minPrice: 3000,
+      maxPrice: 5000,
     });
 
     expect(results[0]?.promoted).toBe(true);
+    expect(results[0]?.id).toBe('a');
   });
 });

--- a/apps/frontend/src/lib/rent/filterRentListings.test.ts
+++ b/apps/frontend/src/lib/rent/filterRentListings.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { STUB_HOTELS } from '@/lib/mockData/hotels';
+import { filterRentListings, toggleFilterValue } from './filterRentListings';
+
+describe('toggleFilterValue', () => {
+  it('adds and removes values from the filter set', () => {
+    expect(toggleFilterValue(['Family'], 'Students')).toEqual([
+      'Family',
+      'Students',
+    ]);
+    expect(toggleFilterValue(['Family', 'Students'], 'Family')).toEqual([
+      'Students',
+    ]);
+  });
+});
+
+describe('filterRentListings', () => {
+  it('filters by category, location, bedrooms, and price', () => {
+    const results = filterRentListings(STUB_HOTELS, {
+      selectedCategories: ['Family'],
+      selectedLocations: ['San José'],
+      selectedBedrooms: '2',
+      sortOption: 'relevance',
+      minPrice: 4000,
+      maxPrice: 4100,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.id).toBe('1');
+  });
+
+  it('sorts promoted listings first when using relevance', () => {
+    const results = filterRentListings(STUB_HOTELS, {
+      selectedCategories: [],
+      selectedLocations: [],
+      selectedBedrooms: 'all',
+      sortOption: 'relevance',
+      minPrice: 3200,
+      maxPrice: 206000,
+    });
+
+    expect(results[0]?.promoted).toBe(true);
+  });
+});

--- a/apps/frontend/src/lib/rent/filterRentListings.ts
+++ b/apps/frontend/src/lib/rent/filterRentListings.ts
@@ -1,0 +1,53 @@
+import type { HotelListing } from '@/@types/hotel';
+
+export type SortOption = 'relevance' | 'price-low' | 'price-high';
+
+export interface RentListingFilters {
+  selectedCategories: string[];
+  selectedLocations: string[];
+  selectedBedrooms: string;
+  sortOption: SortOption;
+  minPrice: number;
+  maxPrice: number;
+}
+
+export function toggleFilterValue(values: string[], value: string): string[] {
+  return values.includes(value)
+    ? values.filter((item) => item !== value)
+    : [...values, value];
+}
+
+export function filterRentListings(
+  listings: HotelListing[],
+  filters: RentListingFilters,
+): HotelListing[] {
+  const apartments = listings.filter((apartment) => {
+    const matchesCategory =
+      filters.selectedCategories.length === 0 ||
+      filters.selectedCategories.includes(apartment.category);
+    const matchesLocation =
+      filters.selectedLocations.length === 0 ||
+      filters.selectedLocations.includes(apartment.location);
+    const matchesBedroom =
+      filters.selectedBedrooms === 'all' ||
+      apartment.bedrooms === Number(filters.selectedBedrooms);
+    const matchesPrice =
+      apartment.price >= filters.minPrice && apartment.price <= filters.maxPrice;
+
+    return (
+      matchesCategory && matchesLocation && matchesBedroom && matchesPrice
+    );
+  });
+
+  if (filters.sortOption === 'price-low') {
+    return [...apartments].sort((left, right) => left.price - right.price);
+  }
+
+  if (filters.sortOption === 'price-high') {
+    return [...apartments].sort((left, right) => right.price - left.price);
+  }
+
+  return [...apartments].sort(
+    (left, right) => Number(right.promoted) - Number(left.promoted),
+  );
+}

--- a/apps/frontend/src/lib/rent/filterRentListings.ts
+++ b/apps/frontend/src/lib/rent/filterRentListings.ts
@@ -1,17 +1,24 @@
-import type { HotelListing } from '@/@types/hotel';
+import type {
+  HotelCategory,
+  HotelListing,
+  HotelLocation,
+} from '@/@types/hotel';
 
 export type SortOption = 'relevance' | 'price-low' | 'price-high';
 
 export interface RentListingFilters {
-  selectedCategories: string[];
-  selectedLocations: string[];
+  selectedCategories: HotelCategory[];
+  selectedLocations: HotelLocation[];
   selectedBedrooms: string;
   sortOption: SortOption;
   minPrice: number;
   maxPrice: number;
 }
 
-export function toggleFilterValue(values: string[], value: string): string[] {
+export function toggleFilterValue<T extends string>(
+  values: T[],
+  value: T,
+): T[] {
   return values.includes(value)
     ? values.filter((item) => item !== value)
     : [...values, value];

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       react-hook-form:
         specifier: ^7.74.0
         version: 7.74.0(react@18.3.1)
+      react-icons:
+        specifier: ^5.5.0
+        version: 5.6.0(react@18.3.1)
       react-qr-code:
         specifier: ^2.0.18
         version: 2.0.18(react@18.3.1)
@@ -190,6 +193,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.6(@types/node@20.19.37)(jiti@1.21.7)(yaml@2.8.3)
 
   packages/graphql:
     devDependencies:
@@ -358,6 +364,162 @@ packages:
   '@envelop/types@5.2.1':
     resolution: {integrity: sha512-CsFmA3u3c2QoLDTfEpGr4t25fjMU31nyvse7IzWTvb0ZycuPjMjb0fjlheh+PbhBYb9YLugnT2uY6Mwcg1o+Zg==}
     engines: {node: '>=18.0.0'}
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -1729,6 +1891,144 @@ packages:
   '@repeaterjs/repeater@3.0.6':
     resolution: {integrity: sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==}
 
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
+    cpu: [x64]
+    os: [win32]
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -2522,6 +2822,9 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
@@ -2551,6 +2854,12 @@ packages:
 
   '@types/d3-timer@3.0.2':
     resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/js-cookie@3.0.6':
     resolution: {integrity: sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==}
@@ -2781,6 +3090,35 @@ packages:
     resolution: {integrity: sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==}
     cpu: [x64]
     os: [win32]
+
+  '@vitest/expect@3.2.6':
+    resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
+
+  '@vitest/mocker@3.2.6':
+    resolution: {integrity: sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.6':
+    resolution: {integrity: sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==}
+
+  '@vitest/runner@3.2.6':
+    resolution: {integrity: sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==}
+
+  '@vitest/snapshot@3.2.6':
+    resolution: {integrity: sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==}
+
+  '@vitest/spy@3.2.6':
+    resolution: {integrity: sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==}
+
+  '@vitest/utils@3.2.6':
+    resolution: {integrity: sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==}
 
   '@wallet-standard/base@1.1.0':
     resolution: {integrity: sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==}
@@ -3024,6 +3362,10 @@ packages:
   asn1.js@4.10.1:
     resolution: {integrity: sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -3249,6 +3591,10 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -3289,6 +3635,10 @@ packages:
     resolution: {integrity: sha512-exQDevYd7ZQLP4moMQcZkKCVZsXLAtUSflObr3xTh4xzFIv/xBCdvCd6L259kQOUP2kcTC0jvC6PpZIf/WmRXA==}
     engines: {node: '>=20'}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -3308,6 +3658,10 @@ packages:
 
   charenc@0.0.2:
     resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -3592,6 +3946,10 @@ packages:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
     engines: {node: '>=0.10'}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -3744,6 +4102,9 @@ packages:
     resolution: {integrity: sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
@@ -3768,6 +4129,11 @@ packages:
 
   es6-promisify@5.0.0:
     resolution: {integrity: sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==}
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -3892,6 +4258,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -3920,6 +4289,10 @@ packages:
 
   evp_bytestokey@1.0.3:
     resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
@@ -4607,6 +4980,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -4751,6 +5127,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lower-case-first@2.0.2:
     resolution: {integrity: sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==}
 
@@ -4774,6 +5153,9 @@ packages:
     resolution: {integrity: sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   map-cache@0.2.2:
     resolution: {integrity: sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==}
@@ -5181,6 +5563,13 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   pbkdf2@3.1.6:
     resolution: {integrity: sha512-BT6eelPB1EyGHo8pC0o9Bl6k6SYVhKO1jEbd3lcTrtr7XHdjP8BW1YpfCV3G9Kwkxgattk+S5q2/RvuttCsS1g==}
     engines: {node: '>= 0.10'}
@@ -5374,6 +5763,11 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
 
+  react-icons@5.6.0:
+    resolution: {integrity: sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==}
+    peerDependencies:
+      react: '*'
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -5561,6 +5955,11 @@ packages:
     resolution: {integrity: sha512-b5rfL2EZiffmklqZk1W+dvSy97v3V/C7936WxCCgDynaGPp7GE6R2XO7EU9O2LlM/z95rj870IylYnOQs+1Rag==}
     engines: {node: '>= 16'}
 
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   rpc-websockets@9.3.8:
     resolution: {integrity: sha512-7r+fm4tSJmLf9GvZfL1DJ1SJwpagpp6AazqM0FUaeV7CA+7+NYINSk1syWa4tU/6OF2CyBicLtzENGmXRJH6wQ==}
 
@@ -5697,6 +6096,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -5765,6 +6167,9 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
@@ -5772,6 +6177,9 @@ packages:
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -5852,6 +6260,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   styled-jsx@5.1.1:
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
@@ -5940,9 +6351,27 @@ packages:
     resolution: {integrity: sha512-eb+F6NabSnjbLwNoC+2o5ItbmP1kg7HliWue71JgLegQt6A5mTN8YbvTLCazdlg6e5SV6A+r8OGvZYskdlmhqQ==}
     engines: {node: '>=6.0.0'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   title-case@3.0.3:
     resolution: {integrity: sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==}
@@ -6283,6 +6712,79 @@ packages:
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.6:
+    resolution: {integrity: sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.6
+      '@vitest/ui': 3.2.6
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
@@ -6330,6 +6832,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wif@5.0.0:
@@ -6714,6 +7221,84 @@ snapshots:
     dependencies:
       '@whatwg-node/promise-helpers': 1.3.2
       tslib: 2.8.1
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1)':
     dependencies:
@@ -8501,6 +9086,81 @@ snapshots:
 
   '@repeaterjs/repeater@3.0.6': {}
 
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    optional: true
+
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.16.1': {}
@@ -9770,6 +10430,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 20.19.37
@@ -9797,6 +10462,10 @@ snapshots:
   '@types/d3-time@3.0.4': {}
 
   '@types/d3-timer@3.0.2': {}
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/js-cookie@3.0.6': {}
 
@@ -10003,6 +10672,48 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
+
+  '@vitest/expect@3.2.6':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.6(vite@7.3.6(@types/node@20.19.37)(jiti@1.21.7)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 3.2.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@20.19.37)(jiti@1.21.7)(yaml@2.8.3)
+
+  '@vitest/pretty-format@3.2.6':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.6':
+    dependencies:
+      '@vitest/utils': 3.2.6
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.6':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@wallet-standard/base@1.1.0': {}
 
@@ -10484,6 +11195,8 @@ snapshots:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   astral-regex@2.0.0: {}
@@ -10742,6 +11455,8 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -10786,6 +11501,14 @@ snapshots:
     dependencies:
       nofilter: 3.1.0
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -10824,6 +11547,8 @@ snapshots:
   chardet@2.1.1: {}
 
   charenc@0.0.2: {}
+
+  check-error@2.1.3: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -11102,6 +11827,8 @@ snapshots:
 
   decode-uri-component@0.2.2: {}
 
+  deep-eql@5.0.2: {}
+
   deep-is@0.1.4: {}
 
   defaults@1.0.4:
@@ -11311,6 +12038,8 @@ snapshots:
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
@@ -11339,6 +12068,35 @@ snapshots:
   es6-promisify@5.0.0:
     dependencies:
       es6-promise: 4.2.8
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -11544,6 +12302,10 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -11573,6 +12335,8 @@ snapshots:
     dependencies:
       md5.js: 1.3.5
       safe-buffer: 5.2.1
+
+  expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
 
@@ -12362,6 +13126,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -12511,6 +13277,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
   lower-case-first@2.0.2:
     dependencies:
       tslib: 2.8.1
@@ -12532,6 +13300,10 @@ snapshots:
   lucide-react@1.21.0(react@18.3.1):
     dependencies:
       react: 18.3.1
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   map-cache@0.2.2: {}
 
@@ -12948,6 +13720,10 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
   pbkdf2@3.1.6:
     dependencies:
       create-hash: 1.2.0
@@ -13166,6 +13942,10 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  react-icons@5.6.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
   react-is@16.13.1: {}
 
   react-qr-code@2.0.18(react@18.3.1):
@@ -13377,6 +14157,37 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  rollup@4.62.2:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
+      fsevents: 2.3.3
+
   rpc-websockets@9.3.8:
     dependencies:
       '@swc/helpers': 0.5.21
@@ -13559,6 +14370,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -13629,9 +14442,13 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  stackback@0.0.2: {}
+
   statuses@1.5.0: {}
 
   statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -13738,6 +14555,10 @@ snapshots:
   strip-bom@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
 
   styled-jsx@5.1.1(@babel/core@7.29.0)(react@18.3.1):
     dependencies:
@@ -13846,10 +14667,20 @@ snapshots:
       elliptic: 6.6.1
       nan: 2.26.2
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   title-case@3.0.3:
     dependencies:
@@ -14158,6 +14989,82 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite-node@3.2.4(@types/node@20.19.37)(jiti@1.21.7)(yaml@2.8.3):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3(supports-color@5.5.0)
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.6(@types/node@20.19.37)(jiti@1.21.7)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.6(@types/node@20.19.37)(jiti@1.21.7)(yaml@2.8.3):
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.8
+      rollup: 4.62.2
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 20.19.37
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      yaml: 2.8.3
+
+  vitest@3.2.6(@types/node@20.19.37)(jiti@1.21.7)(yaml@2.8.3):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.6
+      '@vitest/mocker': 3.2.6(vite@7.3.6(@types/node@20.19.37)(jiti@1.21.7)(yaml@2.8.3))
+      '@vitest/pretty-format': 3.2.6
+      '@vitest/runner': 3.2.6
+      '@vitest/snapshot': 3.2.6
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      debug: 4.4.3(supports-color@5.5.0)
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.6(@types/node@20.19.37)(jiti@1.21.7)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@20.19.37)(jiti@1.21.7)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.37
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
@@ -14227,6 +15134,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wif@5.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ allowBuilds:
   '@stellar/stellar-sdk': false
   blake-hash: false
   bufferutil: false
+  esbuild: true
   protobufjs: false
   secp256k1: false
   tiny-secp256k1: false


### PR DESCRIPTION
## Summary

Homologates the apartment/hotel listing experience from `frontend-SafeTrust` (PR #376 / issue #373) into the dApp monorepo.

- Adds `/rent` listing page with category/location filters, price range slider, bedroom tabs, promoted badges, and sort-by-relevance UI
- Ports `components/rent/` (13 files) from `frontend-SafeTrust/src/components/hotel/`
- Adds `HotelListing` types, mock data (`STUB_HOTELS`), and a dashboard sidebar **Rent** link (`Building2` icon)
- Apartment card clicks route to `/hotel/[id]` (existing detail route; rename to `/rent/[id]` is tracked separately per frontend-SafeTrust #384)
- `app/hotel/` and all escrow sub-routes are **untouched**

Closes #217

## Changes

| Area | What |
|------|------|
| `app/rent/page.tsx` | Full listing page (ported from `frontend-SafeTrust/src/app/hotel/page.tsx`) |
| `components/rent/` | ApartmentCard, ApartmentGrid, FilterSidebar, BedroomTabs, HotelHeader, etc. |
| `@types/hotel.ts` | `HotelListing`, `HotelAmenitySummary`, `HotelOwner` |
| `lib/mockData/` | `hotels.ts`, `apartments.ts` (stub data; Hasura wiring deferred) |
| `lib/rent/filterRentListings.ts` | Extracted filter/sort logic + unit tests |
| `SideBar.tsx` | `/rent` nav entry with active-state highlight |
| `package.json` | `react-icons`, `vitest` |

## Out of scope

- Renaming `app/hotel/[id]/` → `app/rent/[id]/`
- Replacing `STUB_HOTELS` with Hasura `GET_ALL_APARTMENTS` (TODO left in `page.tsx`)
- Adding listing images under `public/img/`

## Test plan (please help me confirm these ones and I get on which are not completed)

- [ ] Open `/rent` — listing page renders with filters, bedroom tabs, and apartment grid
- [ ] Sidebar **Rent** link navigates to `/rent` and highlights when active
- [ ] Category, location, bedroom, and price filters update the grid
- [ ] Clicking an apartment card navigates to `/hotel/[id]`
- [ ] PROMOTED badges appear on promoted listings
- [ ] `pnpm --filter @safetrust/web test` passes
- [ ] `pnpm --filter @safetrust/web lint` — no new warnings in rent files
- [ ] Confirm `app/hotel/` routes still work unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new rent listings experience with filters for category, location, bedrooms, and price, plus sorting options.
  * Introduced listing cards, detail views, image galleries, amenity indicators, and suggested listings.
  * Added a Rent entry in the main navigation.

* **Bug Fixes**
  * Improved listing selection and like/favorite behavior across rent browsing views.
  * Updated pricing display and active filter interactions for a smoother browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->