### PR TITLE
feat: add escrow milestones and trustless work escrow tables with per…

### DIFF
--- a/infra/hasura/metadata/tenants/safetrust/databases/tables/public_escrow_milestones.yaml
+++ b/infra/hasura/metadata/tenants/safetrust/databases/tables/public_escrow_milestones.yaml
@@ -1,0 +1,147 @@
+table:
+  name: escrow_milestones
+  schema: public
+configuration:
+  custom_name: escrowMilestones
+  column_config:
+    escrow_id:
+      custom_name: escrowId
+    milestone_id:
+      custom_name: milestoneId
+    due_date:
+      custom_name: dueDate
+    approved_at:
+      custom_name: approvedAt
+    approved_by:
+      custom_name: approvedBy
+    released_at:
+      custom_name: releasedAt
+    released_by:
+      custom_name: releasedBy
+    created_at:
+      custom_name: createdAt
+    updated_at:
+      custom_name: updatedAt
+    tenant_id:
+      custom_name: tenantId
+object_relationships:
+  - name: escrow
+    using:
+      foreign_key_constraint_on: escrow_id
+select_permissions:
+  - role: tenant
+    permission:
+      columns:
+        - id
+        - escrow_id
+        - milestone_id
+        - description
+        - amount
+        - due_date
+        - status
+        - approved_at
+        - approved_by
+        - released_at
+        - released_by
+        - metadata
+        - created_at
+        - updated_at
+        - tenant_id
+      filter:
+        _and:
+          - tenant_id:
+              _eq: safetrust
+          - escrow:
+              guest_id:
+                _eq: X-Hasura-User-Id
+    comment: Guests can read milestones of the escrows they are the guest on
+  - role: landlord
+    permission:
+      columns:
+        - id
+        - escrow_id
+        - milestone_id
+        - description
+        - amount
+        - due_date
+        - status
+        - approved_at
+        - approved_by
+        - released_at
+        - released_by
+        - metadata
+        - created_at
+        - updated_at
+        - tenant_id
+      filter:
+        _and:
+          - tenant_id:
+              _eq: safetrust
+          - escrow:
+              marker:
+                _eq: X-Hasura-User-Id
+    comment: Hosts can read milestones of the escrows they marked
+insert_permissions:
+  - role: landlord
+    permission:
+      check:
+        _and:
+          - tenant_id:
+              _eq: safetrust
+          - escrow:
+              marker:
+                _eq: X-Hasura-User-Id
+      columns:
+        - escrow_id
+        - milestone_id
+        - description
+        - amount
+        - due_date
+        - status
+        - metadata
+      set:
+        tenant_id: safetrust
+    comment: Hosts define the milestones of the escrows they marked
+update_permissions:
+  - role: tenant
+    permission:
+      columns:
+        - status
+        - metadata
+      filter:
+        _and:
+          - tenant_id:
+              _eq: safetrust
+          - escrow:
+              guest_id:
+                _eq: X-Hasura-User-Id
+      check:
+        _and:
+          - tenant_id:
+              _eq: safetrust
+          - escrow:
+              guest_id:
+                _eq: X-Hasura-User-Id
+    comment: Guests can approve milestones on their own escrows
+  - role: landlord
+    permission:
+      columns:
+        - status
+        - description
+        - due_date
+        - metadata
+      filter:
+        _and:
+          - tenant_id:
+              _eq: safetrust
+          - escrow:
+              marker:
+                _eq: X-Hasura-User-Id
+      check:
+        _and:
+          - tenant_id:
+              _eq: safetrust
+          - escrow:
+              marker:
+                _eq: X-Hasura-User-Id
+    comment: Hosts can maintain milestones on the escrows they marked

--- a/infra/hasura/metadata/tenants/safetrust/databases/tables/public_trustless_work_escrows.yaml
+++ b/infra/hasura/metadata/tenants/safetrust/databases/tables/public_trustless_work_escrows.yaml
@@ -120,8 +120,18 @@ select_permissions:
         _and:
           - tenant_id:
               _eq: safetrust
-          - marker:
-              _eq: X-Hasura-User-Id
+          - _exists:
+              _table:
+                name: user_wallets
+                schema: public
+              _where:
+                _and:
+                  - user_id:
+                      _eq: X-Hasura-User-Id
+                  - wallet_address:
+                      _ceq:
+                        - "$"
+                        - marker
     comment: Hosts can read the escrows they marked
 insert_permissions:
   - role: tenant

--- a/infra/hasura/metadata/tenants/safetrust/databases/tables/public_trustless_work_escrows.yaml
+++ b/infra/hasura/metadata/tenants/safetrust/databases/tables/public_trustless_work_escrows.yaml
@@ -1,0 +1,196 @@
+table:
+  name: trustless_work_escrows
+  schema: public
+configuration:
+  custom_name: trustlessWorkEscrows
+  column_config:
+    contract_id:
+      custom_name: contractId
+    escrow_type:
+      custom_name: escrowType
+    asset_code:
+      custom_name: assetCode
+    asset_issuer:
+      custom_name: assetIssuer
+    booking_id:
+      custom_name: bookingId
+    room_id:
+      custom_name: roomId
+    hotel_id:
+      custom_name: hotelId
+    guest_id:
+      custom_name: guestId
+    check_in_date:
+      custom_name: checkInDate
+    check_out_date:
+      custom_name: checkOutDate
+    booking_created_at:
+      custom_name: bookingCreatedAt
+    escrow_metadata:
+      custom_name: escrowMetadata
+    booking_metadata:
+      custom_name: bookingMetadata
+    created_at:
+      custom_name: createdAt
+    updated_at:
+      custom_name: updatedAt
+    tenant_id:
+      custom_name: tenantId
+array_relationships:
+  - name: milestones
+    using:
+      foreign_key_constraint_on:
+        column: escrow_id
+        table:
+          name: escrow_milestones
+          schema: public
+  # trustless_work_webhook_events.contract_id has no FK constraint, so this is
+  # mapped manually against the UNIQUE contract_id on this table.
+  - name: webhookEvents
+    using:
+      manual_configuration:
+        remote_table:
+          name: trustless_work_webhook_events
+          schema: public
+        column_mapping:
+          contract_id: contract_id
+select_permissions:
+  - role: tenant
+    permission:
+      columns:
+        - id
+        - contract_id
+        - marker
+        - approver
+        - releaser
+        - resolver
+        - escrow_type
+        - status
+        - asset_code
+        - asset_issuer
+        - amount
+        - balance
+        - booking_id
+        - room_id
+        - hotel_id
+        - guest_id
+        - check_in_date
+        - check_out_date
+        - booking_created_at
+        - escrow_metadata
+        - booking_metadata
+        - created_at
+        - updated_at
+        - tenant_id
+      filter:
+        _and:
+          - tenant_id:
+              _eq: safetrust
+          - guest_id:
+              _eq: X-Hasura-User-Id
+    comment: Guests can read the escrows they are the guest on
+  - role: landlord
+    permission:
+      columns:
+        - id
+        - contract_id
+        - marker
+        - approver
+        - releaser
+        - resolver
+        - escrow_type
+        - status
+        - asset_code
+        - asset_issuer
+        - amount
+        - balance
+        - booking_id
+        - room_id
+        - hotel_id
+        - guest_id
+        - check_in_date
+        - check_out_date
+        - booking_created_at
+        - escrow_metadata
+        - booking_metadata
+        - created_at
+        - updated_at
+        - tenant_id
+      filter:
+        _and:
+          - tenant_id:
+              _eq: safetrust
+          - marker:
+              _eq: X-Hasura-User-Id
+    comment: Hosts can read the escrows they marked
+insert_permissions:
+  - role: tenant
+    permission:
+      check:
+        _and:
+          - tenant_id:
+              _eq: safetrust
+          - guest_id:
+              _eq: X-Hasura-User-Id
+      columns:
+        - contract_id
+        - marker
+        - approver
+        - releaser
+        - resolver
+        - escrow_type
+        - status
+        - asset_code
+        - asset_issuer
+        - amount
+        - booking_id
+        - room_id
+        - hotel_id
+        - check_in_date
+        - check_out_date
+        - escrow_metadata
+        - booking_metadata
+      set:
+        tenant_id: safetrust
+        guest_id: X-Hasura-User-Id
+    comment: Guests can create escrows for themselves
+update_permissions:
+  - role: tenant
+    permission:
+      columns:
+        - status
+        - balance
+        - escrow_metadata
+      filter:
+        _and:
+          - tenant_id:
+              _eq: safetrust
+          - guest_id:
+              _eq: X-Hasura-User-Id
+      check:
+        _and:
+          - tenant_id:
+              _eq: safetrust
+          - guest_id:
+              _eq: X-Hasura-User-Id
+    comment: Guests can advance the status of their own escrows
+  - role: landlord
+    permission:
+      columns:
+        - status
+        - balance
+        - booking_metadata
+        - escrow_metadata
+      filter:
+        _and:
+          - tenant_id:
+              _eq: safetrust
+          - marker:
+              _eq: X-Hasura-User-Id
+      check:
+        _and:
+          - tenant_id:
+              _eq: safetrust
+          - marker:
+              _eq: X-Hasura-User-Id
+    comment: Hosts can advance the status of escrows they marked

--- a/infra/hasura/metadata/tenants/safetrust/databases/tables/public_trustless_work_webhook_events.yaml
+++ b/infra/hasura/metadata/tenants/safetrust/databases/tables/public_trustless_work_webhook_events.yaml
@@ -1,0 +1,86 @@
+table:
+  name: trustless_work_webhook_events
+  schema: public
+configuration:
+  custom_name: trustlessWorkWebhookEvents
+  column_config:
+    contract_id:
+      custom_name: contractId
+    event_type:
+      custom_name: eventType
+    processed_at:
+      custom_name: processedAt
+    error_message:
+      custom_name: errorMessage
+    retry_count:
+      custom_name: retryCount
+    max_retries:
+      custom_name: maxRetries
+    next_retry_at:
+      custom_name: nextRetryAt
+    created_at:
+      custom_name: createdAt
+    tenant_id:
+      custom_name: tenantId
+object_relationships:
+  # contract_id carries no FK constraint, so this is mapped manually against the
+  # UNIQUE contract_id on trustless_work_escrows.
+  - name: escrow
+    using:
+      manual_configuration:
+        remote_table:
+          name: trustless_work_escrows
+          schema: public
+        column_mapping:
+          contract_id: contract_id
+# This table is an append-only audit log written by services/webhook, which talks
+# to Hasura with the admin secret and therefore bypasses these permissions. End
+# user roles get read access only — `signature` is withheld from both because it
+# is the HMAC used to verify inbound webhooks.
+select_permissions:
+  - role: tenant
+    permission:
+      columns:
+        - id
+        - contract_id
+        - event_type
+        - payload
+        - processed
+        - processed_at
+        - error_message
+        - retry_count
+        - max_retries
+        - next_retry_at
+        - created_at
+        - tenant_id
+      filter:
+        _and:
+          - tenant_id:
+              _eq: safetrust
+          - escrow:
+              guest_id:
+                _eq: X-Hasura-User-Id
+    comment: Guests can read webhook events of the escrows they are the guest on
+  - role: landlord
+    permission:
+      columns:
+        - id
+        - contract_id
+        - event_type
+        - payload
+        - processed
+        - processed_at
+        - error_message
+        - retry_count
+        - max_retries
+        - next_retry_at
+        - created_at
+        - tenant_id
+      filter:
+        _and:
+          - tenant_id:
+              _eq: safetrust
+          - escrow:
+              marker:
+                _eq: X-Hasura-User-Id
+    comment: Hosts can read webhook events of the escrows they marked

--- a/infra/hasura/metadata/tenants/safetrust/databases/tables/tables.yaml
+++ b/infra/hasura/metadata/tenants/safetrust/databases/tables/tables.yaml
@@ -2,4 +2,7 @@
 - "!include public_user_wallets.yaml"
 - "!include public_apartments.yaml"
 - "!include public_escrows.yaml"
+- "!include public_trustless_work_escrows.yaml"
+- "!include public_escrow_milestones.yaml"
+- "!include public_trustless_work_webhook_events.yaml"
 


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:

feat(hasura): track trustless_work_escrows, escrow_milestones, and trustless_work_webhook_events in infra/hasura metadata

## 🛠️ Issue

- Closes #229 


## 📚 Description

Three of the four canonical escrow tables existed as orphaned DDL: created by the migrations,
but untracked in Hasura metadata, so they had no GraphQL surface and no permissions. This PR
tracks them, using the same `custom_name` camelCase alias pattern already established in
`backend-SafeTrust`, so GraphQL field names stay consistent across both repos.

Two items from the issue are intentionally **not** included, because the issue's premises don't
hold in this repo:

**1. `escrow_transactions` is not tracked — the table does not exist here.**
There is no migration for it, and no reference to it anywhere in the codebase. The
`backend-SafeTrust` equivalent depends on `bid_requests`, the `escrow_transaction_type` /
`escrow_status` enum types, and the `escrow_xdr_transactions` table — none of which exist in
this repo. Tracking it would produce exactly the `WARN Metadata is inconsistent` the issue asks
us to eliminate. It needs a migration first, in a separate issue.

**2. `metadata/build/` is not mirrored — it is generated, not source.**
It is gitignored (`build/`, `infra/hasura/.gitignore:39`) and `build-metadata.sh` does
`rm -rf "$BUILD_DIR/$tenant"` and regenerates it from `base/` + `tenants/` on every run.
Hand-written files there cannot be committed and would be wiped by the next `dc_prep`.
Tracking in `tenants/` already covers it.

### Adaptation decisions

- **Roles:** uses this repo's actual roles (`tenant` / `landlord`), not `backend-SafeTrust`'s
  (`user` / `admin`), which are not defined here.
- **Tenant filter:** uses a literal `tenant_id: _eq: safetrust` per the acceptance criteria.
  `backend-SafeTrust` filters on the `X-Hasura-Tenant-Id` session variable, which no auth path
  in this repo ever sets.
- **`trustless_work_webhook_events` is select-only**, not select/insert/update as the issue
  lists. It is an append-only audit log written by `services/webhook`, which talks to Hasura
  with the admin secret and therefore bypasses these permissions anyway. Granting write access
  to end-user roles would let a client forge webhook events. The `signature` column (the HMAC
  used to verify inbound webhooks) is withheld from both roles.
- **Dropped the legacy `custom_column_names` block** present in the `backend-SafeTrust` source
  file: it contradicts its own `column_config` (`CreatedAt` vs `createdAt`) and is superseded in
  metadata v3.
- Omitted the `escrow_pending_approvals` relationship (table does not exist here) and the
  `on_condition_verified` event trigger (its `/events/condition-verified` endpoint is not
  implemented in `services/webhook`).

## ✅ Changes applied

**New files** — `infra/hasura/metadata/tenants/safetrust/databases/tables/`

- `public_trustless_work_escrows.yaml` — tracked as `trustlessWorkEscrows`. camelCase column
  aliases; `milestones` array relationship (FK on `escrow_id`); `webhookEvents` array
  relationship via `manual_configuration` (`trustless_work_webhook_events.contract_id` carries
  no FK constraint, so it is mapped against the UNIQUE `contract_id` on this table).
  select/insert/update for `tenant` (scoped by `guest_id`) and `landlord` (scoped by `marker`).
- `public_escrow_milestones.yaml` — tracked as `escrowMilestones`. camelCase column aliases;
  `escrow` object relationship via the existing `escrow_id` FK. select/insert/update scoped
  through the `escrow` relationship.
- `public_trustless_work_webhook_events.yaml` — tracked as `trustlessWorkWebhookEvents`.
  camelCase column aliases; `escrow` object relationship via `manual_configuration` on
  `contract_id`. Select-only, `signature` withheld (see Description).

**Modified**

- `tables.yaml` — added the three `!include` entries.

All row filters are `tenant_id: _eq: safetrust` AND a participant check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new support for trustless work escrow records, including camel-cased GraphQL field naming.
  * Added escrow milestones with due dates, approval timestamps, status, descriptions, and metadata.
  * Added webhook event visibility tied to escrow contracts.
  * Introduced role-based access controls for both tenant and landlord views across escrows, milestones, and webhook events, with column-level restrictions and row-level filtering.
  * Connected escrows to their related milestones and webhook events through defined relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->