### PR TITLE
Feat 241 escrow dashboard real hasura

### DIFF
--- a/apps/frontend/src/app/dashboard/escrow-dashboard/RoleEscrowDashboardPage.tsx
+++ b/apps/frontend/src/app/dashboard/escrow-dashboard/RoleEscrowDashboardPage.tsx
@@ -46,14 +46,22 @@ type TrustlessWorkEscrowRow = {
 
 type GetEscrowsDashboardQuery = {
   escrows?: EscrowRow[];
+  recent_escrows?: EscrowRow[];
+  escrows_aggregate?: {
+    aggregate?: {
+      count?: number | null;
+    } | null;
+  };
   trustless_work_escrows?: TrustlessWorkEscrowRow[];
 };
 
 type EscrowFilter = {
-  _or: Array<{
+  _and?: Array<EscrowFilter>;
+  _or?: Array<{
     sender_address?: { _eq: string };
     receiver_address?: { _eq: string };
   }>;
+  updated_at?: { _gte: string };
 };
 
 type TrustlessWorkEscrowFilter = {
@@ -69,8 +77,15 @@ type GetEscrowsDashboardVariables = {
   limit: number;
   offset: number;
   where: EscrowFilter;
+  recentWhere: EscrowFilter;
   trustlessWorkWhere: TrustlessWorkEscrowFilter;
 };
+
+const normalizeWalletAddress = (value: unknown) =>
+  typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+
+const getRecentEscrowCutoff = () =>
+  new Date(Date.now() - ONE_DAY_IN_MS).toISOString();
 
 const getStoredWalletAddress = () => {
   if (typeof window === "undefined") return null;
@@ -83,9 +98,11 @@ const getStoredWalletAddress = () => {
 
   try {
     const parsed = JSON.parse(storedWallet);
-    return typeof parsed === "string" ? parsed : parsed?.address ?? null;
+    return normalizeWalletAddress(
+      typeof parsed === "string" ? parsed : parsed?.address,
+    );
   } catch {
-    return storedWallet;
+    return normalizeWalletAddress(storedWallet);
   }
 };
 
@@ -97,6 +114,10 @@ const mapEscrowStatus = (status?: string | null): DashboardEscrowStatus => {
     case "active":
     case "milestone_approved":
       return "funded";
+    case "check_in_approved":
+      return "check_in_approved";
+    case "check_out_approved":
+      return "check_out_approved";
     case "completed":
     case "resolved":
       return "completed";
@@ -130,7 +151,7 @@ const mapEscrows = (
     return {
       id: escrow.id,
       contractId: escrow.contract_id ?? escrow.id,
-      status: mapEscrowStatus(escrow.status),
+      status: mapEscrowStatus(escrow.status || trustlessWorkEscrow?.status),
       amount: Number(escrow.amount) || 0,
       asset: {
         code: "USDC",
@@ -206,19 +227,34 @@ export function RoleEscrowDashboardPage() {
   const [userRole, setUserRole] = useState<"guest" | "hotel" | "admin">("guest");
   const storeAddress = useGlobalAuthenticationStore((state) => state.address);
   const [storedAddress, setStoredAddress] = useState<string | null>(null);
+  const [recentEscrowCutoff, setRecentEscrowCutoff] = useState(
+    getRecentEscrowCutoff,
+  );
 
   const walletAddress = storeAddress ?? storedAddress;
 
   const variables = useMemo<GetEscrowsDashboardVariables | undefined>(() => {
     if (!walletAddress) return undefined;
 
+    const walletEscrowFilter: EscrowFilter = {
+      _or: [
+        { sender_address: { _eq: walletAddress } },
+        { receiver_address: { _eq: walletAddress } },
+      ],
+    };
+
     return {
       limit: DASHBOARD_ESCROW_LIMIT,
       offset: 0,
-      where: {
-        _or: [
-          { sender_address: { _eq: walletAddress } },
-          { receiver_address: { _eq: walletAddress } },
+      where: walletEscrowFilter,
+      recentWhere: {
+        _and: [
+          walletEscrowFilter,
+          {
+            updated_at: {
+              _gte: recentEscrowCutoff,
+            },
+          },
         ],
       },
       trustlessWorkWhere: {
@@ -230,7 +266,7 @@ export function RoleEscrowDashboardPage() {
         ],
       },
     };
-  }, [walletAddress]);
+  }, [recentEscrowCutoff, walletAddress]);
 
   const { data, loading, error, refetch } = useQuery<
     GetEscrowsDashboardQuery,
@@ -251,17 +287,32 @@ export function RoleEscrowDashboardPage() {
     [data?.escrows, data?.trustless_work_escrows],
   );
 
+  const recentEscrows = useMemo(
+    () => mapEscrows(data?.recent_escrows, data?.trustless_work_escrows),
+    [data?.recent_escrows, data?.trustless_work_escrows],
+  );
+
   const notifications = useMemo(
-    () => deriveNotifications(escrows),
-    [escrows],
+    () => deriveNotifications(recentEscrows),
+    [recentEscrows],
   );
 
   const handleRefresh = useCallback(() => {
     setUserRole(getUserRole() ?? "guest");
     setStoredAddress(getStoredWalletAddress());
+    const nextRecentEscrowCutoff = getRecentEscrowCutoff();
+    setRecentEscrowCutoff(nextRecentEscrowCutoff);
 
     if (variables) {
-      void refetch(variables);
+      void refetch({
+        ...variables,
+        recentWhere: {
+          _and: [
+            variables.where,
+            { updated_at: { _gte: nextRecentEscrowCutoff } },
+          ],
+        },
+      });
     }
   }, [refetch, variables]);
 
@@ -269,6 +320,7 @@ export function RoleEscrowDashboardPage() {
     <RoleEscrowDashboard
       userRole={userRole}
       escrows={escrows}
+      totalEscrows={data?.escrows_aggregate?.aggregate?.count ?? escrows.length}
       notifications={notifications}
       isLoading={loading}
       error={error ? "Failed to load escrow dashboard data." : null}

--- a/apps/frontend/src/app/dashboard/escrow-dashboard/RoleEscrowDashboardPage.tsx
+++ b/apps/frontend/src/app/dashboard/escrow-dashboard/RoleEscrowDashboardPage.tsx
@@ -1,52 +1,279 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useQuery } from "@apollo/client";
 import { RoleEscrowDashboard } from "@/components/dashboard/RoleEscrowDashboard";
 import type {
   EscrowData,
   NotificationData,
 } from "@/components/dashboard/RoleEscrowDashboard";
-import {
-  fetchMockEscrows,
-  generateMockNotifications,
-} from "@/lib/mockData";
+import { useGlobalAuthenticationStore } from "@/core/store/data";
+import { GET_ESCROWS } from "@/graphql/queries/escrow-queries";
 import { getUserRole } from "@/utils/role-utils";
+
+const DASHBOARD_ESCROW_LIMIT = 50;
+const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+type DashboardEscrowStatus = EscrowData["status"];
+
+type EscrowRow = {
+  id: string;
+  contract_id?: string | null;
+  engagement_id?: string | null;
+  amount: number | string;
+  status?: string | null;
+  created_at: string;
+  updated_at?: string | null;
+  sender_address?: string | null;
+  receiver_address?: string | null;
+  apartment?: {
+    name?: string | null;
+    available_from?: string | null;
+    available_until?: string | null;
+  } | null;
+};
+
+type TrustlessWorkEscrowRow = {
+  contract_id?: string | null;
+  status?: string | null;
+  asset_code?: string | null;
+  asset_issuer?: string | null;
+  marker?: string | null;
+  booking_id?: string | null;
+  check_in_date?: string | null;
+  check_out_date?: string | null;
+  updated_at?: string | null;
+};
+
+type GetEscrowsDashboardQuery = {
+  escrows?: EscrowRow[];
+  trustless_work_escrows?: TrustlessWorkEscrowRow[];
+};
+
+type EscrowFilter = {
+  _or: Array<{
+    sender_address?: { _eq: string };
+    receiver_address?: { _eq: string };
+  }>;
+};
+
+type TrustlessWorkEscrowFilter = {
+  _or: Array<{
+    marker?: { _eq: string };
+    approver?: { _eq: string };
+    releaser?: { _eq: string };
+    resolver?: { _eq: string };
+  }>;
+};
+
+type GetEscrowsDashboardVariables = {
+  limit: number;
+  offset: number;
+  where: EscrowFilter;
+  trustlessWorkWhere: TrustlessWorkEscrowFilter;
+};
+
+const getStoredWalletAddress = () => {
+  if (typeof window === "undefined") return null;
+
+  const storedWallet =
+    localStorage.getItem("walletAddress") ||
+    localStorage.getItem("address-wallet");
+
+  if (!storedWallet) return null;
+
+  try {
+    const parsed = JSON.parse(storedWallet);
+    return typeof parsed === "string" ? parsed : parsed?.address ?? null;
+  } catch {
+    return storedWallet;
+  }
+};
+
+const mapEscrowStatus = (status?: string | null): DashboardEscrowStatus => {
+  const normalized = status?.toLowerCase();
+
+  switch (normalized) {
+    case "funded":
+    case "active":
+    case "milestone_approved":
+      return "funded";
+    case "completed":
+    case "resolved":
+      return "completed";
+    case "disputed":
+    case "cancelled":
+      return "cancelled";
+    case "pending_signature":
+    case "deploying":
+    case "created":
+    case "pending_funding":
+    default:
+      return "pending";
+  }
+};
+
+const mapEscrows = (
+  escrows: EscrowRow[] = [],
+  trustlessWorkEscrows: TrustlessWorkEscrowRow[] = [],
+): EscrowData[] => {
+  const trustlessWorkByContractId = new Map(
+    trustlessWorkEscrows
+      .filter((escrow) => escrow.contract_id)
+      .map((escrow) => [escrow.contract_id, escrow]),
+  );
+
+  return escrows.map((escrow) => {
+    const trustlessWorkEscrow = escrow.contract_id
+      ? trustlessWorkByContractId.get(escrow.contract_id)
+      : undefined;
+
+    return {
+      id: escrow.id,
+      contractId: escrow.contract_id ?? escrow.id,
+      status: mapEscrowStatus(escrow.status),
+      amount: Number(escrow.amount) || 0,
+      asset: {
+        code: trustlessWorkEscrow?.asset_code ?? "USDC",
+        issuer: trustlessWorkEscrow?.asset_issuer ?? undefined,
+      },
+      metadata: {
+        bookingId:
+          escrow.engagement_id ?? trustlessWorkEscrow?.booking_id ?? escrow.id,
+        hotelName: escrow.apartment?.name ?? "Unknown apartment",
+        checkInDate:
+          escrow.apartment?.available_from ??
+          trustlessWorkEscrow?.check_in_date ??
+          escrow.created_at,
+        checkOutDate:
+          escrow.apartment?.available_until ??
+          trustlessWorkEscrow?.check_out_date ??
+          escrow.updated_at ??
+          escrow.created_at,
+      },
+      marker:
+        escrow.receiver_address ??
+        trustlessWorkEscrow?.marker ??
+        escrow.sender_address ??
+        "",
+      createdAt: escrow.created_at,
+      updatedAt:
+        escrow.updated_at ??
+        trustlessWorkEscrow?.updated_at ??
+        escrow.created_at,
+    };
+  });
+};
+
+const notificationTypeByStatus: Record<DashboardEscrowStatus, NotificationData["type"]> = {
+  pending: "alert",
+  funded: "payment",
+  check_in_approved: "milestone",
+  check_out_approved: "milestone",
+  completed: "milestone",
+  cancelled: "alert",
+};
+
+const notificationMessageByStatus: Record<DashboardEscrowStatus, string> = {
+  pending: "is pending signature",
+  funded: "has been funded",
+  check_in_approved: "has check-in approved",
+  check_out_approved: "has check-out approved",
+  completed: "has been completed",
+  cancelled: "was cancelled",
+};
+
+const deriveNotifications = (escrows: EscrowData[]): NotificationData[] => {
+  const now = Date.now();
+
+  return escrows
+    .filter((escrow) => {
+      const updatedAt = new Date(escrow.updatedAt).getTime();
+      return !Number.isNaN(updatedAt) && now - updatedAt <= ONE_DAY_IN_MS;
+    })
+    .map((escrow) => ({
+      id: `${escrow.id}-${escrow.status}-${escrow.updatedAt}`,
+      type: notificationTypeByStatus[escrow.status],
+      message: `Escrow ${escrow.metadata?.bookingId ?? escrow.id} ${
+        notificationMessageByStatus[escrow.status]
+      }`,
+      timestamp: escrow.updatedAt,
+      read: false,
+      escrowId: escrow.id,
+    }));
+};
 
 export function RoleEscrowDashboardPage() {
   const [userRole, setUserRole] = useState<"guest" | "hotel" | "admin">("guest");
-  const [escrows, setEscrows] = useState<EscrowData[]>([]);
-  const [notifications, setNotifications] = useState<NotificationData[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const storeAddress = useGlobalAuthenticationStore((state) => state.address);
+  const [storedAddress, setStoredAddress] = useState<string | null>(null);
 
-  const loadData = useCallback(async () => {
-    setIsLoading(true);
-    setError(null);
-    try {
-      const role = getUserRole();
-      setUserRole(role ?? "guest");
-      const escrowData = await fetchMockEscrows();
-      setEscrows(escrowData);
-      setNotifications(generateMockNotifications(escrowData));
-    } catch {
-      setError("Failed to load escrow dashboard data.");
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
+  const walletAddress = storeAddress ?? storedAddress;
+
+  const variables = useMemo<GetEscrowsDashboardVariables | undefined>(() => {
+    if (!walletAddress) return undefined;
+
+    return {
+      limit: DASHBOARD_ESCROW_LIMIT,
+      offset: 0,
+      where: {
+        _or: [
+          { sender_address: { _eq: walletAddress } },
+          { receiver_address: { _eq: walletAddress } },
+        ],
+      },
+      trustlessWorkWhere: {
+        _or: [
+          { marker: { _eq: walletAddress } },
+          { approver: { _eq: walletAddress } },
+          { releaser: { _eq: walletAddress } },
+          { resolver: { _eq: walletAddress } },
+        ],
+      },
+    };
+  }, [walletAddress]);
+
+  const { data, loading, error, refetch } = useQuery<
+    GetEscrowsDashboardQuery,
+    GetEscrowsDashboardVariables
+  >(GET_ESCROWS, {
+    variables,
+    skip: !variables,
+    fetchPolicy: "cache-and-network",
+  });
 
   useEffect(() => {
-    loadData();
-  }, [loadData]);
+    setUserRole(getUserRole() ?? "guest");
+    setStoredAddress(getStoredWalletAddress());
+  }, []);
+
+  const escrows = useMemo(
+    () => mapEscrows(data?.escrows, data?.trustless_work_escrows),
+    [data?.escrows, data?.trustless_work_escrows],
+  );
+
+  const notifications = useMemo(
+    () => deriveNotifications(escrows),
+    [escrows],
+  );
+
+  const handleRefresh = useCallback(() => {
+    setUserRole(getUserRole() ?? "guest");
+    setStoredAddress(getStoredWalletAddress());
+
+    if (variables) {
+      void refetch(variables);
+    }
+  }, [refetch, variables]);
 
   return (
     <RoleEscrowDashboard
       userRole={userRole}
       escrows={escrows}
       notifications={notifications}
-      isLoading={isLoading}
-      error={error}
-      onRefresh={loadData}
+      isLoading={loading}
+      error={error ? "Failed to load escrow dashboard data." : null}
+      onRefresh={handleRefresh}
     />
   );
 }

--- a/apps/frontend/src/app/dashboard/escrow-dashboard/RoleEscrowDashboardPage.tsx
+++ b/apps/frontend/src/app/dashboard/escrow-dashboard/RoleEscrowDashboardPage.tsx
@@ -36,7 +36,6 @@ type EscrowRow = {
 type TrustlessWorkEscrowRow = {
   contract_id?: string | null;
   status?: string | null;
-  asset_code?: string | null;
   asset_issuer?: string | null;
   marker?: string | null;
   booking_id?: string | null;
@@ -134,7 +133,7 @@ const mapEscrows = (
       status: mapEscrowStatus(escrow.status),
       amount: Number(escrow.amount) || 0,
       asset: {
-        code: trustlessWorkEscrow?.asset_code ?? "USDC",
+        code: "USDC",
         issuer: trustlessWorkEscrow?.asset_issuer ?? undefined,
       },
       metadata: {

--- a/apps/frontend/src/components/dashboard/RoleEscrowDashboard.tsx
+++ b/apps/frontend/src/components/dashboard/RoleEscrowDashboard.tsx
@@ -65,6 +65,14 @@ export interface NotificationData {
   escrowId?: string;
 }
 
+const sortNotificationsByTimestamp = (notifications: NotificationData[]) =>
+  [...notifications].sort(
+    (a, b) =>
+      new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+  );
+
+const EMPTY_NOTIFICATIONS: NotificationData[] = [];
+
 export interface Milestone {
   id: string;
   name: string;
@@ -82,6 +90,7 @@ const formatNotificationTimestamp = (timestamp: string) => {
 interface RoleEscrowDashboardProps {
   userRole: "guest" | "hotel" | "admin";
   escrows?: EscrowData[];
+  totalEscrows?: number;
   notifications?: NotificationData[];
   isLoading?: boolean;
   error?: string | null;
@@ -91,7 +100,8 @@ interface RoleEscrowDashboardProps {
 export function RoleEscrowDashboard({
   userRole,
   escrows = [],
-  notifications: initialNotifications = [],
+  totalEscrows,
+  notifications: initialNotifications = EMPTY_NOTIFICATIONS,
   isLoading = false,
   error = null,
   onRefresh,
@@ -103,8 +113,27 @@ export function RoleEscrowDashboard({
   const isMountedRef = useRef(true);
   const isPollingRef = useRef(false);
 
+  useEffect(() => {
+    setNotifications((prev) => {
+      const mergedById = new Map(
+        prev.map((notification) => [notification.id, notification]),
+      );
+
+      initialNotifications.forEach((notification) => {
+        const existing = mergedById.get(notification.id);
+        mergedById.set(notification.id, {
+          ...notification,
+          read: existing?.read ?? notification.read,
+        });
+      });
+
+      return sortNotificationsByTimestamp(Array.from(mergedById.values()));
+    });
+  }, [initialNotifications]);
+
    // Real-time updates using Trustless Work notifications
    useEffect(() => {
+     isMountedRef.current = true;
      if (isLoading) return;
 
      const checkUpdates = async () => {
@@ -131,7 +160,7 @@ export function RoleEscrowDashboard({
              const newNotifications = uniqueNotifications.filter(
                (n) => !existingIds.has(n.id),
              );
-             return [...prev, ...newNotifications];
+             return sortNotificationsByTimestamp([...prev, ...newNotifications]);
            });
          }
        } catch (error) {
@@ -204,7 +233,7 @@ export function RoleEscrowDashboard({
                   Total Escrows
                 </p>
                 <p className="text-2xl font-bold mt-1 dark:text-white">
-                  {escrows.length}
+                  {totalEscrows ?? escrows.length}
                 </p>
               </div>
               <div className="p-3 rounded-lg bg-blue-50 dark:bg-blue-900/30">

--- a/apps/frontend/src/graphql/queries/escrow-queries.ts
+++ b/apps/frontend/src/graphql/queries/escrow-queries.ts
@@ -6,6 +6,7 @@ export const GET_ESCROWS = gql`
     $limit: Int!
     $offset: Int!
     $where: escrows_bool_exp = {}
+    $recentWhere: escrows_bool_exp = {}
     $trustlessWorkWhere: trustless_work_escrows_bool_exp = {}
   ) {
     escrows(
@@ -35,6 +36,28 @@ export const GET_ESCROWS = gql`
     escrows_aggregate(where: $where) {
       aggregate {
         count
+      }
+    }
+    recent_escrows: escrows(
+      where: $recentWhere
+      order_by: { updated_at: desc }
+    ) {
+      id
+      contract_id
+      engagement_id
+      amount
+      status
+      created_at
+      updated_at
+      sender_address
+      receiver_address
+      apartment {
+        id
+        name
+        address
+        image_urls
+        available_from
+        available_until
       }
     }
     trustless_work_escrows(

--- a/apps/frontend/src/graphql/queries/escrow-queries.ts
+++ b/apps/frontend/src/graphql/queries/escrow-queries.ts
@@ -44,7 +44,6 @@ export const GET_ESCROWS = gql`
       id
       contract_id
       status
-      asset_code
       asset_issuer
       marker
       booking_id

--- a/apps/frontend/src/graphql/queries/escrow-queries.ts
+++ b/apps/frontend/src/graphql/queries/escrow-queries.ts
@@ -2,10 +2,16 @@
 import { gql } from "@apollo/client";
 
 export const GET_ESCROWS = gql`
-  query GetEscrows($limit: Int!, $offset: Int!) {
+  query GetEscrows(
+    $limit: Int!
+    $offset: Int!
+    $where: escrows_bool_exp = {}
+    $trustlessWorkWhere: trustless_work_escrows_bool_exp = {}
+  ) {
     escrows(
       limit: $limit
       offset: $offset
+      where: $where
       order_by: { created_at: desc }
     ) {
       id
@@ -14,6 +20,7 @@ export const GET_ESCROWS = gql`
       amount
       status
       created_at
+      updated_at
       sender_address
       receiver_address
       apartment {
@@ -21,12 +28,30 @@ export const GET_ESCROWS = gql`
         name
         address
         image_urls
+        available_from
+        available_until
       }
     }
-    escrows_aggregate {
+    escrows_aggregate(where: $where) {
       aggregate {
         count
       }
+    }
+    trustless_work_escrows(
+      where: $trustlessWorkWhere
+      order_by: { updated_at: desc }
+    ) {
+      id
+      contract_id
+      status
+      asset_code
+      asset_issuer
+      marker
+      booking_id
+      check_in_date
+      check_out_date
+      created_at
+      updated_at
     }
   }
 `;

--- a/apps/frontend/src/lib/mockData.ts
+++ b/apps/frontend/src/lib/mockData.ts
@@ -120,7 +120,9 @@ export const generateMockEscrows = (count: number = 10): EscrowData[] => {
   });
 };
 
-// Generate mock notifications
+/**
+ * @deprecated RoleEscrowDashboardPage derives notifications from Hasura escrow data.
+ */
 export const generateMockNotifications = (escrows: EscrowData[]): NotificationData[] => {
   const notifications: NotificationData[] = [];
   
@@ -187,7 +189,9 @@ export const generateMockNotifications = (escrows: EscrowData[]): NotificationDa
   );
 };
 
-// Helper functions to be used in the components
+/**
+ * @deprecated RoleEscrowDashboardPage now loads escrows with GET_ESCROWS.
+ */
 export const fetchMockEscrows = async (): Promise<EscrowData[]> => {
   // Simulate network delay
   await new Promise(resolve => setTimeout(resolve, 500));


### PR DESCRIPTION
## Summary

Closes #241 

This PR replaces the escrow dashboard mock data flow with real Hasura data through Apollo `GET_ESCROWS`.

`RoleEscrowDashboardPage` no longer calls `fetchMockEscrows()` or `generateMockNotifications()`. Instead, it queries real escrow rows from `public.escrows`, includes related apartment data, joins the available `trustless_work_escrows` data by `contract_id`, maps the database shape into the existing `EscrowData` interface, and derives notification state from real escrow updates.

## Changes

- Replaced mock escrow loading in `RoleEscrowDashboardPage` with Apollo `useQuery(GET_ESCROWS)`.
- Added wallet-based filters for:
  - `sender_address`
  - `receiver_address`
  - TrustlessWork roles: `marker`, `approver`, `releaser`, `resolver`
- Added mapping from Hasura escrow rows to `EscrowData`.
- Added status normalization:
  - `pending_signature`, `deploying`, `created`, `pending_funding` → `pending`
  - `funded`, `active`, `milestone_approved` → `funded`
  - `completed`, `resolved` → `completed`
  - `disputed`, `cancelled` → `cancelled`
- Mapped apartment data into dashboard metadata:
  - `apartment.name` → `metadata.hotelName`
  - `engagement_id` → `metadata.bookingId`
  - `apartment.available_from` → `metadata.checkInDate`
  - `apartment.available_until` → `metadata.checkOutDate`
- Kept `asset.code` hardcoded as `USDC`, as requested.
- Derived notifications from escrows updated in the last 24 hours.
- Extended `GET_ESCROWS` to include:
  - `updated_at`
  - `apartment.available_from`
  - `apartment.available_until`
  - `trustless_work_escrows`
  - optional Hasura filters
- Marked `fetchMockEscrows` and `generateMockNotifications` as deprecated without deleting `mockData.ts`.

## Verification

Ran:

```bash
npx pnpm@9.15.9 --filter @safetrust/web exec tsc --noEmit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Escrow dashboards now load live, wallet-scoped escrow data with refresh support.
  * Dashboard notifications are now derived from recently updated escrow activity.
  * Added support for trustless-work escrow details and apartment availability date ranges.
  * “Total Escrows” display can reflect live totals.
* **Bug Fixes**
  * Dashboard loading and error states now correctly mirror the live data request status.
  * Escrow counts now stay consistent with the applied filters, including “recent” results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->