### PR TITLE
feat: implement escrow lifecycle webhook handlers and update server s…

### DIFF
--- a/infra/hasura/docker-compose.yml
+++ b/infra/hasura/docker-compose.yml
@@ -63,6 +63,8 @@ services:
       FIREBASE_CLIENT_EMAIL: ${FIREBASE_CLIENT_EMAIL}
       FIREBASE_PRIVATE_KEY: ${FIREBASE_PRIVATE_KEY}
       FRONTEND_URL: http://localhost:3001
+      HASURA_GRAPHQL_ENDPOINT: http://graphql-engine:8080/v1/graphql
+      HASURA_GRAPHQL_ADMIN_SECRET: "myadminsecretkey"
     depends_on:
       postgres:
         condition: service_healthy

--- a/services/webhook/.env.example
+++ b/services/webhook/.env.example
@@ -1,0 +1,23 @@
+# ── Server ───────────────────────────────────────────────
+PORT=3000
+
+# ── PostgreSQL (auth / user sync) ────────────────────────
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5433
+POSTGRES_DB=postgres
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgrespassword
+
+# ── Hasura (escrow lifecycle webhook handlers) ───────────
+# Docker network: http://graphql-engine:8080/v1/graphql
+# Local host:     http://localhost:8080/v1/graphql
+HASURA_GRAPHQL_ENDPOINT=http://localhost:8080/v1/graphql
+HASURA_GRAPHQL_ADMIN_SECRET=myadminsecretkey
+
+# ── Firebase Admin SDK (auth routes) ─────────────────────
+FIREBASE_PROJECT_ID=
+FIREBASE_CLIENT_EMAIL=
+FIREBASE_PRIVATE_KEY=
+
+# ── CORS ─────────────────────────────────────────────────
+FRONTEND_URL=http://localhost:3001

--- a/services/webhook/Dockerfile
+++ b/services/webhook/Dockerfile
@@ -7,4 +7,4 @@ RUN addgroup -S appgroup && adduser -S appuser -G appgroup \
   && chown -R appuser:appgroup /app
 USER appuser
 EXPOSE 3000
-CMD ["node", "src/index.js"]
+CMD ["node", "src/server.js"]

--- a/services/webhook/package.json
+++ b/services/webhook/package.json
@@ -1,10 +1,10 @@
 {
   "name": "webhook",
   "version": "1.0.0",
-  "main": "src/index.js",
+  "main": "src/server.js",
   "scripts": {
-    "dev": "node src/index.js",
-    "start": "node src/index.js"
+    "dev": "node src/server.js",
+    "start": "node src/server.js"
   },
   "dependencies": {
     "cors": "^2.8.6",

--- a/services/webhook/src/app.js
+++ b/services/webhook/src/app.js
@@ -18,7 +18,12 @@ app.use(cors({
   credentials: true,
 }));
 
-app.use(express.json());
+// Capture the raw request body so webhook signatures (HMAC) can be verified.
+app.use(express.json({
+  verify: (req, _res, buf) => {
+    req.rawBody = buf;
+  },
+}));
 
 const router = require('./routes');
 app.use(router);

--- a/services/webhook/src/index.js
+++ b/services/webhook/src/index.js
@@ -1,6 +1,0 @@
-const app = require('./app');
-
-const port = process.env.PORT || 3000;
-app.listen(port, () => {
-  console.log(`[webhook] Server running on http://localhost:${port}`);
-});

--- a/services/webhook/src/routes/escrows/approve-milestone.handler.js
+++ b/services/webhook/src/routes/escrows/approve-milestone.handler.js
@@ -1,0 +1,166 @@
+'use strict';
+
+const DEFAULT_HASURA_ENDPOINT = 'http://graphql-engine:8080/v1/graphql';
+
+function getHasuraEndpoint() {
+  const configured = process.env.HASURA_GRAPHQL_ENDPOINT || DEFAULT_HASURA_ENDPOINT;
+  return configured.endsWith('/v1/graphql') ? configured : `${configured.replace(/\/$/, '')}/v1/graphql`;
+}
+
+async function postHasura(query, variables) {
+  const adminSecret = process.env.HASURA_GRAPHQL_ADMIN_SECRET;
+
+  if (!adminSecret) {
+    throw new Error('Missing HASURA_GRAPHQL_ADMIN_SECRET');
+  }
+
+  const response = await fetch(getHasuraEndpoint(), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-hasura-admin-secret': adminSecret,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    throw new Error(`Hasura request failed with status ${response.status}`);
+  }
+
+  if (data.errors) {
+    const error = new Error('Hasura mutation failed');
+    error.details = data.errors;
+    throw error;
+  }
+
+  return data.data;
+}
+
+async function approveMilestoneHandler(req, res) {
+  const { contractId, milestoneId, approver, flag } = req.body || {};
+
+  if (!contractId || !milestoneId || !approver || flag === undefined) {
+    return res.status(400).json({
+      error: 'Missing required fields: contractId, milestoneId, approver, flag',
+    });
+  }
+
+  if (flag !== true) {
+    return res.status(400).json({
+      error: 'flag must be true to approve a milestone',
+    });
+  }
+
+  const approvedAt = new Date().toISOString();
+
+  try {
+    // Step 1: Look up the escrow ID using camelCase fields. Query root and
+    // mutation roots are camelCase because the tables are tracked with
+    // custom_name (trustlessWorkEscrows / escrowMilestones), see Issue 5.
+    let escrowId;
+
+    const lookupQuery = `
+      query GetEscrowId($contractId: String!) {
+        trustlessWorkEscrows(where: { contractId: { _eq: $contractId } }) {
+          id
+        }
+      }
+    `;
+    const data = await postHasura(lookupQuery, { contractId });
+    if (data.trustlessWorkEscrows && data.trustlessWorkEscrows.length > 0) {
+      escrowId = data.trustlessWorkEscrows[0].id;
+    }
+
+    if (!escrowId) {
+      return res.status(404).json({
+        error: 'Escrow or milestone not found',
+      });
+    }
+
+    // Step 2: Perform the updates using the found escrowId UUID
+    const mutationMilestone = `
+      mutation ApproveMilestone(
+        $escrowId: uuid!
+        $milestoneId: String!
+        $approver: String!
+        $approvedAt: timestamptz!
+      ) {
+        update_escrowMilestones(
+          where: {
+            escrowId: { _eq: $escrowId }
+            milestoneId: { _eq: $milestoneId }
+          }
+          _set: {
+            status: "approved"
+            approvedBy: $approver
+            approvedAt: $approvedAt
+            updatedAt: $approvedAt
+          }
+        ) {
+          affected_rows
+        }
+      }
+    `;
+    const resultMilestone = await postHasura(mutationMilestone, {
+      escrowId,
+      milestoneId,
+      approver,
+      approvedAt
+    });
+    const milestoneRows = resultMilestone.update_escrowMilestones?.affected_rows || 0;
+
+    if (milestoneRows === 0) {
+      return res.status(404).json({
+        error: 'Escrow or milestone not found',
+      });
+    }
+
+    const mutationEscrow = `
+      mutation ApproveEscrow(
+        $escrowId: uuid!
+        $approvedAt: timestamptz!
+      ) {
+        update_trustlessWorkEscrows(
+          where: {
+            id: { _eq: $escrowId }
+          }
+          _set: {
+            status: "milestone_approved"
+            updatedAt: $approvedAt
+          }
+        ) {
+          affected_rows
+        }
+      }
+    `;
+    const resultEscrow = await postHasura(mutationEscrow, {
+      escrowId,
+      approvedAt
+    });
+    const escrowRows = resultEscrow.update_trustlessWorkEscrows?.affected_rows || 0;
+
+    if (escrowRows === 0) {
+      return res.status(404).json({
+        error: 'Escrow or milestone not found',
+      });
+    }
+
+    console.log(
+      `[escrow/approve-milestone] milestone approved — contractId=${contractId} milestoneId=${milestoneId}`
+    );
+    return res.status(200).json({ received: true });
+  } catch (error) {
+    console.error('[escrow/approve-milestone] failed:', error.details || error.message);
+    return res.status(500).json({
+      error: 'Failed to update milestone approval',
+    });
+  }
+}
+
+module.exports = {
+  approveMilestoneHandler,
+  getHasuraEndpoint,
+  postHasura,
+};

--- a/services/webhook/src/routes/escrows/approve-milestone.route.js
+++ b/services/webhook/src/routes/escrows/approve-milestone.route.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const express = require('express');
+const { approveMilestoneHandler } = require('./approve-milestone.handler');
+
+const router = express.Router();
+
+router.post('/api/escrows/approve-milestone', approveMilestoneHandler);
+
+module.exports = router;

--- a/services/webhook/src/routes/escrows/dispute.handler.js
+++ b/services/webhook/src/routes/escrows/dispute.handler.js
@@ -1,0 +1,70 @@
+const disputeEscrowHandler = async (req, res) => {
+  const { contractId, disputeFlag, disputer } = req.body;
+
+  if (!contractId || disputeFlag === undefined || !disputer) {
+    return res.status(400).json({
+      error: 'Missing required fields: contractId, disputeFlag, disputer'
+    });
+  }
+
+  if (disputeFlag !== true) {
+    return res.status(400).json({
+      error: 'disputeFlag must be true to open a dispute'
+    });
+  }
+
+  // update_trustlessWorkEscrows is camelCase because the table is tracked with
+  // custom_name: trustlessWorkEscrows (see infra/hasura metadata, Issue 5).
+  const mutation = `
+    mutation DisputeEscrow($contractId: String!) {
+      update_trustlessWorkEscrows(
+        where: { contractId: { _eq: $contractId } }
+        _set: {
+          status: "disputed",
+          updatedAt: "now()"
+        }
+      ) {
+        returning { id contractId status }
+      }
+    }
+  `;
+
+  try {
+    const endpoint = process.env.HASURA_GRAPHQL_ENDPOINT;
+    const adminSecret = process.env.HASURA_GRAPHQL_ADMIN_SECRET;
+
+    if (!endpoint) {
+      console.error('[escrow/dispute] HASURA_GRAPHQL_ENDPOINT is not configured');
+      return res.status(500).json({ error: 'Server configuration error' });
+    }
+
+    const hasuraRes = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(adminSecret ? { 'x-hasura-admin-secret': adminSecret } : {}),
+      },
+      body: JSON.stringify({ query: mutation, variables: { contractId } }),
+    });
+
+    const hasuraData = await hasuraRes.json();
+
+    if (hasuraData.errors) {
+      console.error('[escrow/dispute] Hasura error:', hasuraData.errors);
+      return res.status(500).json({ error: 'Failed to update escrow status', details: hasuraData.errors });
+    }
+
+    const updated = hasuraData.data?.update_trustlessWorkEscrows?.returning;
+    if (!updated || !updated.length) {
+      return res.status(404).json({ error: `Escrow not found for contractId: ${contractId}` });
+    }
+
+    console.log(`[escrow/dispute] Dispute opened — contractId: ${contractId}, disputer: ${disputer}`);
+    return res.status(200).json({ received: true });
+  } catch (error) {
+    console.error('[escrow/dispute] Exception:', error.message);
+    return res.status(500).json({ error: 'Internal server error', details: error.message });
+  }
+};
+
+module.exports = { disputeEscrowHandler };

--- a/services/webhook/src/routes/escrows/dispute.route.js
+++ b/services/webhook/src/routes/escrows/dispute.route.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const { disputeEscrowHandler } = require('./dispute.handler');
+
+const router = express.Router();
+router.post('/api/escrows/dispute', disputeEscrowHandler);
+
+module.exports = router;

--- a/services/webhook/src/routes/escrows/fund.handler.js
+++ b/services/webhook/src/routes/escrows/fund.handler.js
@@ -27,7 +27,7 @@ const fundEscrowHandler = async (req, res) => {
         _set: {
           status: "funded",
           balance: $amount,
-          updatedAt: "now()"
+          updatedAt: "${new Date().toISOString()}"
         }
       ) {
         returning {

--- a/services/webhook/src/routes/escrows/fund.handler.js
+++ b/services/webhook/src/routes/escrows/fund.handler.js
@@ -1,0 +1,96 @@
+const fundEscrowHandler = async (req, res) => {
+  const { contractId, signer, amount } = req.body;
+
+  // 1 — Validate required fields
+  if (!contractId || !signer || amount === undefined || amount === null) {
+    return res.status(400).json({
+      error: 'Missing required fields: contractId, signer, amount'
+    });
+  }
+
+  if (amount <= 0) {
+    return res.status(400).json({
+      error: 'Amount cannot be zero or negative'
+    });
+  }
+
+  // 2 — Update public.trustless_work_escrows via Hasura GraphQL mutation.
+  // update_trustlessWorkEscrows is camelCase because the table is tracked with
+  // custom_name: trustlessWorkEscrows (see infra/hasura metadata, Issue 5).
+  const mutation = `
+    mutation FundEscrow($contractId: String!, $amount: numeric!) {
+      update_trustlessWorkEscrows(
+        where: {
+          contractId: { _eq: $contractId },
+          status: { _in: ["created", "pending_funding"] }
+        }
+        _set: {
+          status: "funded",
+          balance: $amount,
+          updatedAt: "now()"
+        }
+      ) {
+        returning {
+          id
+          contractId
+          status
+          balance
+        }
+      }
+    }
+  `;
+
+  try {
+    const endpoint = process.env.HASURA_GRAPHQL_ENDPOINT;
+    const adminSecret = process.env.HASURA_GRAPHQL_ADMIN_SECRET;
+
+    if (!endpoint) {
+      console.error('[escrow/fund] HASURA_GRAPHQL_ENDPOINT is not configured');
+      return res.status(500).json({ error: 'Server configuration error' });
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10000);
+
+    const hasuraRes = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(adminSecret ? { 'x-hasura-admin-secret': adminSecret } : {}),
+      },
+      body: JSON.stringify({
+        query: mutation,
+        variables: { contractId, amount }
+      }),
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+
+    const hasuraData = await hasuraRes.json();
+
+    if (hasuraData.errors) {
+      console.error('[escrow/fund] Hasura error:', hasuraData.errors);
+      return res.status(500).json({
+        error: 'Failed to update escrow status'
+      });
+    }
+
+    const updated = hasuraData.data?.update_trustlessWorkEscrows?.returning;
+
+    if (!updated || !updated.length) {
+      return res.status(404).json({
+        error: `Escrow not found for contractId: ${contractId}`
+      });
+    }
+
+    console.log(`[escrow/fund] Escrow funded — contractId: ${contractId}, amount: ${amount}`);
+
+    // 3 — Acknowledge TrustlessWork webhook
+    return res.status(200).json({ received: true });
+  } catch (error) {
+    console.error('[escrow/fund] Exception:', error.message);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+};
+
+module.exports = { fundEscrowHandler };

--- a/services/webhook/src/routes/escrows/fund.route.js
+++ b/services/webhook/src/routes/escrows/fund.route.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const { fundEscrowHandler } = require('./fund.handler');
+
+const router = express.Router();
+
+// No authMiddleware — this is a TrustlessWork callback, not a user request
+router.post('/api/escrows/fund', fundEscrowHandler);
+
+module.exports = router;

--- a/services/webhook/src/routes/escrows/initialize.handler.js
+++ b/services/webhook/src/routes/escrows/initialize.handler.js
@@ -1,0 +1,115 @@
+const initializeEscrowHandler = async (req, res) => {
+  const {
+    contract_id,
+    marker,
+    approver,
+    releaser,
+    resolver,
+    amount,
+    escrow_type,
+    asset_code,
+    asset_issuer,
+    booking_id,
+    room_id,
+    hotel_id,
+    guest_id,
+    booking_metadata,
+  } = req.body;
+
+  // 1 — Validate required fields
+  if (!contract_id || !marker || !approver || !releaser || !amount || !escrow_type) {
+    return res.status(400).json({
+      error: 'Missing required fields: contract_id, marker, approver, releaser, amount, escrow_type'
+    });
+  }
+
+  // 2 — Validate escrow_type matches migration CHECK constraint
+  const validTypes = ['single_release', 'multi_release'];
+  if (!validTypes.includes(escrow_type)) {
+    return res.status(400).json({
+      error: `escrow_type must be one of: ${validTypes.join(', ')}`
+    });
+  }
+
+  // 3 — Persist to public.trustless_work_escrows via Hasura GraphQL mutation.
+  // Root fields and input type are camelCase because the table is tracked with
+  // custom_name: trustlessWorkEscrows (see infra/hasura metadata, Issue 5).
+  const mutation = `
+    mutation InitializeEscrow($object: trustlessWorkEscrows_insert_input!) {
+      insert_trustlessWorkEscrows_one(object: $object) {
+        id
+        contractId
+        status
+        createdAt
+      }
+    }
+  `;
+
+  try {
+    const endpoint = process.env.HASURA_GRAPHQL_ENDPOINT;
+    const adminSecret = process.env.HASURA_GRAPHQL_ADMIN_SECRET;
+
+    if (!endpoint) {
+      console.error('[escrow/initialize] HASURA_GRAPHQL_ENDPOINT is not configured');
+      return res.status(500).json({ error: 'Server configuration error' });
+    }
+
+    const hasuraRes = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(adminSecret ? { 'x-hasura-admin-secret': adminSecret } : {}),
+      },
+      body: JSON.stringify({
+        query: mutation,
+        variables: {
+          object: {
+            contractId: contract_id,
+            marker,
+            approver,
+            releaser,
+            resolver: resolver || null,
+            escrowType: escrow_type,
+            status: 'created',             // initial status per valid_escrow_status CHECK
+            assetCode: asset_code || 'USDC',
+            assetIssuer: asset_issuer || null,
+            amount,
+            balance: 0,
+            bookingId: booking_id || null,
+            roomId: room_id || null,
+            hotelId: hotel_id || null,
+            guestId: guest_id || null,
+            tenantId: 'safetrust',
+            escrowMetadata: req.body,     // full payload stored as JSONB
+            bookingMetadata: booking_metadata || null,
+          }
+        }
+      }),
+    });
+
+    const hasuraData = await hasuraRes.json();
+
+    if (hasuraData.errors) {
+      console.error('[escrow/initialize] Hasura error:', hasuraData.errors);
+      return res.status(500).json({
+        error: 'Failed to persist escrow record',
+        details: hasuraData.errors
+      });
+    }
+
+    const escrow = hasuraData.data?.insert_trustlessWorkEscrows_one;
+    if (!escrow) {
+      return res.status(500).json({ error: 'Failed to insert escrow record' });
+    }
+
+    console.log(`[escrow/initialize] Escrow persisted — contract_id: ${contract_id}, id: ${escrow.id}`);
+
+    // 4 — Acknowledge TrustlessWork webhook
+    return res.status(200).json({ received: true });
+  } catch (error) {
+    console.error('[escrow/initialize] Exception:', error.message);
+    return res.status(500).json({ error: 'Internal server error', details: error.message });
+  }
+};
+
+module.exports = { initializeEscrowHandler };

--- a/services/webhook/src/routes/escrows/initialize.route.js
+++ b/services/webhook/src/routes/escrows/initialize.route.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const { initializeEscrowHandler } = require('./initialize.handler');
+
+const router = express.Router();
+
+// No authMiddleware — TrustlessWork is the caller, not a Firebase-authenticated user
+router.post('/api/escrows/initialize', initializeEscrowHandler);
+
+module.exports = router;

--- a/services/webhook/src/routes/escrows/release-funds.handler.js
+++ b/services/webhook/src/routes/escrows/release-funds.handler.js
@@ -1,0 +1,66 @@
+const releaseFundsHandler = async (req, res) => {
+  const { contractId, releaseSigner } = req.body;
+
+  if (!contractId || !releaseSigner) {
+    return res.status(400).json({
+      error: 'Missing required fields: contractId, releaseSigner'
+    });
+  }
+
+  // update_trustlessWorkEscrows is camelCase because the table is tracked with
+  // custom_name: trustlessWorkEscrows (see infra/hasura metadata, Issue 5).
+  const mutation = `
+    mutation ReleaseFunds($contractId: String!) {
+      update_trustlessWorkEscrows(
+        where: { contractId: { _eq: $contractId } }
+        _set: {
+          status: "completed",
+          balance: 0,
+          updatedAt: "now()"
+        }
+      ) {
+        returning { id contractId status balance }
+      }
+    }
+  `;
+
+  try {
+    const endpoint = process.env.HASURA_GRAPHQL_ENDPOINT;
+    const adminSecret = process.env.HASURA_GRAPHQL_ADMIN_SECRET;
+
+    if (!endpoint) {
+      console.error('[escrow/release-funds] HASURA_GRAPHQL_ENDPOINT is not configured');
+      return res.status(500).json({ error: 'Server configuration error' });
+    }
+
+    const hasuraRes = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(adminSecret ? { 'x-hasura-admin-secret': adminSecret } : {}),
+      },
+      body: JSON.stringify({ query: mutation, variables: { contractId } }),
+    });
+
+    const hasuraData = await hasuraRes.json();
+
+    if (hasuraData.errors) {
+      console.error('[escrow/release-funds] Hasura error:', hasuraData.errors);
+      return res.status(500).json({ error: 'Failed to update escrow status', details: hasuraData.errors });
+    }
+
+    const updated = hasuraData.data?.update_trustlessWorkEscrows?.returning;
+
+    if (!updated || !updated.length) {
+      return res.status(404).json({ error: `Escrow not found for contractId: ${contractId}` });
+    }
+
+    console.log(`[escrow/release-funds] Funds released — contractId: ${contractId}`);
+    return res.status(200).json({ received: true });
+  } catch (error) {
+    console.error('[escrow/release-funds] Exception:', error.message);
+    return res.status(500).json({ error: 'Internal server error', details: error.message });
+  }
+};
+
+module.exports = { releaseFundsHandler };

--- a/services/webhook/src/routes/escrows/release-funds.route.js
+++ b/services/webhook/src/routes/escrows/release-funds.route.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const { releaseFundsHandler } = require('./release-funds.handler');
+
+const router = express.Router();
+router.post('/api/escrows/release-funds', releaseFundsHandler);
+
+module.exports = router;

--- a/services/webhook/src/routes/escrows/resolve-dispute.handler.js
+++ b/services/webhook/src/routes/escrows/resolve-dispute.handler.js
@@ -1,0 +1,86 @@
+const resolveDisputeHandler = async (req, res) => {
+  const { contractId, resolver, resolutionNote } = req.body;
+
+  // 1 — Validate required fields
+  if (!contractId || !resolver) {
+    return res.status(400).json({
+      error: 'Missing required fields: contractId, resolver'
+    });
+  }
+
+  // 2 — Update public.trustless_work_escrows via Hasura GraphQL mutation.
+  // update_trustlessWorkEscrows is camelCase because the table is tracked with
+  // custom_name: trustlessWorkEscrows (see infra/hasura metadata, Issue 5).
+  const mutation = `
+    mutation ResolveDispute($contractId: String!) {
+      update_trustlessWorkEscrows(
+        where: {
+          contractId: { _eq: $contractId },
+          status: { _eq: "disputed" }
+        }
+        _set: {
+          status: "resolved",
+          balance: 0,
+          updatedAt: "now()"
+        }
+      ) {
+        returning {
+          id
+          contractId
+          status
+          balance
+        }
+      }
+    }
+  `;
+
+  try {
+    const endpoint = process.env.HASURA_GRAPHQL_ENDPOINT;
+    const adminSecret = process.env.HASURA_GRAPHQL_ADMIN_SECRET;
+
+    if (!endpoint) {
+      console.error('[escrow/resolve-dispute] HASURA_GRAPHQL_ENDPOINT is not configured');
+      return res.status(500).json({ error: 'Server configuration error' });
+    }
+
+    const hasuraRes = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(adminSecret ? { 'x-hasura-admin-secret': adminSecret } : {}),
+      },
+      body: JSON.stringify({
+        query: mutation,
+        variables: { contractId }
+      }),
+    });
+
+    const hasuraData = await hasuraRes.json();
+
+    if (hasuraData.errors) {
+      console.error('[escrow/resolve-dispute] Hasura error:', hasuraData.errors);
+      return res.status(500).json({
+        error: 'Failed to update escrow status',
+        details: hasuraData.errors
+      });
+    }
+
+    const updated = hasuraData.data?.update_trustlessWorkEscrows?.returning;
+
+    if (!updated || !updated.length) {
+      return res.status(404).json({
+        error: `Escrow not found for contractId: ${contractId}`
+      });
+    }
+
+    console.log(`[escrow/resolve-dispute] Dispute resolved — contractId: ${contractId}, resolver: ${resolver}`);
+
+    // 3 — Acknowledge TrustlessWork webhook
+    return res.status(200).json({ received: true });
+  } catch (error) {
+    console.error('[escrow/resolve-dispute] Exception:', error.message);
+    return res.status(500).json({ error: 'Internal server error', details: error.message });
+  }
+};
+
+module.exports = { resolveDisputeHandler };

--- a/services/webhook/src/routes/escrows/resolve-dispute.route.js
+++ b/services/webhook/src/routes/escrows/resolve-dispute.route.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const { resolveDisputeHandler } = require('./resolve-dispute.handler');
+
+const router = express.Router();
+
+// No authMiddleware — this is a TrustlessWork callback
+router.post('/api/escrows/resolve-dispute', resolveDisputeHandler);
+
+module.exports = router;

--- a/services/webhook/src/routes/index.js
+++ b/services/webhook/src/routes/index.js
@@ -3,10 +3,26 @@ const router = express.Router();
 const { authenticateFirebase } = require('../middleware/auth');
 const authRoutes = require('./auth');
 
-// Public routes — no auth required
+// Escrow lifecycle webhooks — TrustlessWork is the caller, not a Firebase user.
+const initializeEscrowRoute = require('./escrows/initialize.route');
+const fundEscrowRoute = require('./escrows/fund.route');
+const approveMilestoneRoute = require('./escrows/approve-milestone.route');
+const releaseFundsRoute = require('./escrows/release-funds.route');
+const disputeRoute = require('./escrows/dispute.route');
+const resolveDisputeRoute = require('./escrows/resolve-dispute.route');
+
+// 1. Health check — public
 router.get('/health', (req, res) => res.status(200).json({ status: 'ok' }));
 
-// Protected routes — authenticateFirebase runs before every route below
+// 2. Public Webhooks — MUST be registered before the Firebase auth middleware
+router.use(initializeEscrowRoute);
+router.use(fundEscrowRoute);
+router.use(approveMilestoneRoute);
+router.use(releaseFundsRoute);
+router.use(disputeRoute);
+router.use(resolveDisputeRoute);
+
+// 3. Protected routes — authenticateFirebase runs before every route below
 router.use('/api/auth', authenticateFirebase, authRoutes);
 
 module.exports = router;

--- a/services/webhook/src/server.js
+++ b/services/webhook/src/server.js
@@ -1,0 +1,22 @@
+const app = require('./app');
+
+const port = Number(process.env.PORT || 3000);
+
+/**
+ * HTTP server entrypoint for the webhook service.
+ */
+const server = app.listen(port, () => {
+  console.log(`[webhook] Server running on http://localhost:${port}`);
+});
+
+server.on('error', (err) => {
+  console.error('[webhook] failed to start', err);
+  process.exit(1);
+});
+
+for (const sig of ['SIGTERM', 'SIGINT']) {
+  process.on(sig, () => {
+    console.log(`[webhook] ${sig} received, shutting down`);
+    server.close(() => process.exit(0));
+  });
+}


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:

feat(services/webhook): port escrow lifecycle webhook handlers from backend-SafeTrust

## 🛠️ Issue

- Closes #232 
- Depends on Issue 5 (Hasura metadata) — verified against that metadata

## 📚 Description

Ports the six escrow lifecycle webhook handlers from `backend-SafeTrust/webhook/src/routes/escrows/`
(post-Issue-436) into the dApp's own `services/webhook`, so the dApp stack is self-contained.
Until now the webhook service only handled auth (`sync-user`); `POST /api/escrows/*` returned 404.

Each handler persists to Hasura over GraphQL (`fetch` + admin secret), keyed by `contractId`,
using the camelCase column aliases defined by the Issue-5 metadata.

### One non-verbatim change was required for the handlers to work

The `backend-SafeTrust` handlers use **snake_case GraphQL root fields**
(`insert_trustless_work_escrows_one`, `update_trustless_work_escrows`, `update_escrow_milestones`)
with camelCase columns. But the Issue-5 metadata tracks these tables with
`custom_name: trustlessWorkEscrows` / `escrowMilestones`, which makes Hasura generate **camelCase
root fields**. I confirmed this empirically against a live Hasura — the actual roots are
`insert_trustlessWorkEscrows_one`, `update_trustlessWorkEscrows`, `update_escrowMilestones`, and
the insert input type is `trustlessWorkEscrows_insert_input`.

Ported verbatim, all six handlers would fail with `field not found in mutation_root` and every
acceptance criterion would fail. So the ported handlers use the camelCase root-field and
input-type names that match this repo's metadata. Columns stay camelCase, as the issue requires.
(This is a latent inconsistency in `backend-SafeTrust` itself — its handlers and its metadata
disagree — surfaced here because nothing had exercised these mutations yet.)

### Deviations from the issue's file list (the issue's premises didn't hold)

- **`server.js` did not exist**, and `package.json` `start` pointed to `index.js` (the issue
  states it already pointed to `server.js`). Created `server.js` with graceful shutdown, updated
  `package.json`, updated the `Dockerfile` `CMD` (also `index.js`, not mentioned in the issue),
  and deleted `index.js`.
- `server.js` listens on port **3000**, so the docker-compose port mapping and health check
  (`http://localhost:3000/health`) keep working.
- **Wired the Hasura env vars.** Added `HASURA_GRAPHQL_ENDPOINT` +
  `HASURA_GRAPHQL_ADMIN_SECRET` to the webhook service in `docker-compose.yml`, and added
  `services/webhook/.env.example`. Not in the issue's file list, but without them the
  "row inserted" acceptance criteria can't pass in the Docker stack — the issue itself calls out
  that `HASURA_GRAPHQL_ENDPOINT` must be set.

### Notes

- Handlers capture `req.rawBody` (via `express.json({ verify })`) as requested, but no handler
  verifies an HMAC signature yet — that's forward-looking infra for a later issue.
- This PR depends on Issue 5 being merged. It was verified against exactly that metadata
  (`custom_name: trustlessWorkEscrows`). If Issue 5 merges with different root-field naming, the
  handler root fields would need to be realigned.

## ✅ Changes applied

**New — `services/webhook/src/routes/escrows/` (12 files)**
- `initialize.{handler,route}.js` — `POST /api/escrows/initialize`, inserts the escrow (status `created`).
- `fund.{handler,route}.js` — `POST /api/escrows/fund`, status → `funded`, sets balance.
- `approve-milestone.{handler,route}.js` — `POST /api/escrows/approve-milestone`, milestone → `approved`, escrow → `milestone_approved`.
- `release-funds.{handler,route}.js` — `POST /api/escrows/release-funds`, status → `completed`.
- `dispute.{handler,route}.js` — `POST /api/escrows/dispute`, status → `disputed`.
- `resolve-dispute.{handler,route}.js` — `POST /api/escrows/resolve-dispute`, status → `resolved`.

**New — other**
- `services/webhook/src/server.js` — HTTP entrypoint (port 3000, graceful SIGTERM/SIGINT shutdown).
- `services/webhook/.env.example` — documents PORT, Postgres, Hasura, Firebase, CORS vars.

**Modified**
- `services/webhook/src/routes/index.js` — registers all 6 escrow routes in a "Public Webhooks" block before the Firebase auth middleware. Existing auth routing unchanged.
- `services/webhook/src/app.js` — `express.json({ verify })` to capture the raw body.
- `services/webhook/package.json` + `services/webhook/Dockerfile` — point to `server.js`.
- `infra/hasura/docker-compose.yml` — Hasura env vars on the webhook service.

**Deleted**
- `services/webhook/src/index.js`.


- ✅ AC1 `initialize` → `{ received: true }` 200, row inserted in `trustless_work_escrows`, status `created`
- ✅ AC2 `fund` → status `funded`
- ✅ AC3 `approve-milestone` → `escrow_milestones.status` = `approved`
- ✅ AC4 `release-funds` → status `completed`
- ✅ AC5 `dispute` → status `disputed`
- ✅ AC6 `resolve-dispute` → status `resolved`
- ✅ AC7 `/api/auth/sync-user` returns 401 (reaches the auth middleware), not 404 — auth unaffected
- ✅ AC8 `node src/server.js` starts cleanly (`/health` → `{ status: "ok" }`)
- ✅ Validation guards intact: missing fields → 400, unknown contract → 404




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added webhook endpoints for escrow initialization, funding, milestone approval, fund release, dispute creation, and dispute resolution.
  - Escrow actions now validate incoming data and update their status accordingly.
  - Added webhook signature support and configurable service environment settings.
- **Bug Fixes**
  - Improved webhook startup and shutdown handling for more reliable service operation.
  - Added clearer handling for missing records, invalid requests, and processing failures.
- **Chores**
  - Updated service startup configuration to use the new server entry point.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->