### PR TITLE
feat(api): add POST /api/escrow/recover-from-txhash

### DIFF
--- a/apps/frontend/src/app/api/escrow/recover-from-txhash/route.test.ts
+++ b/apps/frontend/src/app/api/escrow/recover-from-txhash/route.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/server/hasura', () => ({
+  updateEscrowStatusByContractId: vi.fn(),
+}));
+
+vi.mock('@/lib/server/trustlesswork', () => ({
+  trustlessWorkRequest: vi.fn(),
+  TrustlessWorkRequestError: class extends Error {
+    statusCode: number;
+    messages?: string[];
+    payload?: unknown;
+    constructor(message: string, statusCode: number, messages?: string[], payload?: unknown) {
+      super(message);
+      this.statusCode = statusCode;
+      this.messages = messages;
+      this.payload = payload;
+    }
+  },
+}));
+
+import { POST } from './route';
+import { updateEscrowStatusByContractId } from '@/lib/server/hasura';
+import { trustlessWorkRequest } from '@/lib/server/trustlesswork';
+
+const mockUpdate = vi.mocked(updateEscrowStatusByContractId);
+const mockIndexer = vi.mocked(trustlessWorkRequest);
+
+function req(body: unknown, { badJson = false } = {}) {
+  return {
+    json: async () => {
+      if (badJson) throw new Error('bad json');
+      return body;
+    },
+  } as unknown as Parameters<typeof POST>[0];
+}
+
+function affected(rows: number) {
+  return { update_escrows: { affected_rows: rows } };
+}
+
+const validFund = { txHash: 'a3f9', action: 'fund', contractId: 'CAZT', amount: 950 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIndexer.mockResolvedValue({} as never);
+  mockUpdate.mockResolvedValue(affected(1));
+});
+
+describe('POST /api/escrow/recover-from-txhash — validation', () => {
+  it('400 on invalid JSON', async () => {
+    const res = await POST(req(null, { badJson: true }));
+    expect(res.status).toBe(400);
+  });
+
+  it('400 when txHash missing', async () => {
+    const res = await POST(req({ action: 'fund', contractId: 'CAZT', amount: 1 }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/txHash/);
+  });
+
+  it('400 when action missing', async () => {
+    const res = await POST(req({ txHash: 'a3f9', contractId: 'CAZT' }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/action/);
+  });
+
+  it('400 listing valid options on invalid action', async () => {
+    const res = await POST(req({ txHash: 'a3f9', action: 'nope', contractId: 'CAZT' }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/initialize, fund/);
+  });
+
+  it('400 when contractId missing', async () => {
+    const res = await POST(req({ txHash: 'a3f9', action: 'fund', amount: 1 }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/contractId/);
+  });
+
+  it('400 when an action-specific field is missing (fund without amount)', async () => {
+    const res = await POST(req({ txHash: 'a3f9', action: 'fund', contractId: 'CAZT' }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/amount/);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('400 when approve_milestone is missing approver', async () => {
+    const res = await POST(
+      req({ txHash: 'a3f9', action: 'approve_milestone', contractId: 'CAZT', milestoneId: 'm1' }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/approver/);
+  });
+});
+
+describe('POST /api/escrow/recover-from-txhash — recovery flow', () => {
+  it('re-indexes in TW before updating the DB', async () => {
+    const order: string[] = [];
+    mockIndexer.mockImplementation(async () => {
+      order.push('indexer');
+      return {} as never;
+    });
+    mockUpdate.mockImplementation(async () => {
+      order.push('db');
+      return affected(1);
+    });
+
+    await POST(req(validFund));
+
+    expect(mockIndexer).toHaveBeenCalledWith('/indexer/update-from-txHash', {
+      method: 'POST',
+      body: { txHash: 'a3f9' },
+    });
+    expect(order).toEqual(['indexer', 'db']);
+  });
+
+  it('continues DB recovery even when the TW indexer call fails', async () => {
+    mockIndexer.mockRejectedValue(new Error('TW down'));
+    const res = await POST(req(validFund));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ recovered: true, action: 'fund' });
+    expect(mockUpdate).toHaveBeenCalledOnce();
+  });
+
+  it('returns recovered payload with the mapped status', async () => {
+    const res = await POST(req(validFund));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      recovered: true,
+      action: 'fund',
+      contractId: 'CAZT',
+      txHash: 'a3f9',
+      status: 'funded',
+    });
+  });
+
+  it.each([
+    ['initialize', 'pending_signature', { engagementId: 'e', apartmentId: 'ap', senderAddress: 's', receiverAddress: 'r', releaser: 'rl', amount: 1 }],
+    ['fund', 'funded', { amount: 1 }],
+    ['approve_milestone', 'funded', { milestoneId: 'm', approver: 'ap' }],
+    ['release_funds', 'completed', { releaseSigner: 'rs' }],
+    ['dispute', 'disputed', {}],
+    ['resolve_dispute', 'resolved', {}],
+  ])('maps action %s to escrow status %s', async (action, status, extra) => {
+    const res = await POST(req({ txHash: 'a3f9', action, contractId: 'CAZT', ...extra }));
+    expect(res.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalledWith('CAZT', status);
+  });
+
+  it('404 when no escrow row matches contractId', async () => {
+    mockUpdate.mockResolvedValue(affected(0));
+    const res = await POST(req(validFund));
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toMatch(/No escrow record/);
+  });
+
+  it('500 when the DB update throws', async () => {
+    mockUpdate.mockRejectedValue(new Error('hasura boom'));
+    const res = await POST(req(validFund));
+    expect(res.status).toBe(500);
+  });
+});

--- a/apps/frontend/src/app/api/escrow/recover-from-txhash/route.ts
+++ b/apps/frontend/src/app/api/escrow/recover-from-txhash/route.ts
@@ -1,0 +1,133 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { getErrorMessages } from '@/lib/trustlesswork-errors';
+import {
+  TrustlessWorkRequestError,
+  trustlessWorkRequest,
+} from '@/lib/server/trustlesswork';
+import { updateEscrowStatusByContractId } from '@/lib/server/hasura';
+
+type RecoverAction =
+  | 'initialize'
+  | 'fund'
+  | 'approve_milestone'
+  | 'release_funds'
+  | 'dispute'
+  | 'resolve_dispute';
+
+type RecoverRequestBody = {
+  txHash?: string;
+  action?: RecoverAction;
+  contractId?: string;
+  engagementId?: string;
+  apartmentId?: string;
+  senderAddress?: string;
+  receiverAddress?: string;
+  releaser?: string;
+  amount?: number;
+  milestoneId?: string;
+  approver?: string;
+  releaseSigner?: string;
+};
+
+const VALID_ACTIONS: RecoverAction[] = [
+  'initialize',
+  'fund',
+  'approve_milestone',
+  'release_funds',
+  'dispute',
+  'resolve_dispute',
+];
+
+// Maps a recovered action to the escrows.status it should leave behind.
+const ACTION_STATUS: Record<RecoverAction, string> = {
+  initialize: 'pending_signature',
+  fund: 'funded',
+  approve_milestone: 'funded',
+  release_funds: 'completed',
+  dispute: 'disputed',
+  resolve_dispute: 'resolved',
+};
+
+// Fields each action must carry beyond contractId, so a recovery request is
+// well-formed and auditable even though the DB correction itself is a status set.
+const REQUIRED_FIELDS: Record<RecoverAction, (keyof RecoverRequestBody)[]> = {
+  initialize: ['engagementId', 'apartmentId', 'senderAddress', 'receiverAddress', 'releaser', 'amount'],
+  fund: ['amount'],
+  approve_milestone: ['milestoneId', 'approver'],
+  release_funds: ['releaseSigner'],
+  dispute: [],
+  resolve_dispute: [],
+};
+
+export async function POST(request: NextRequest) {
+  let body: RecoverRequestBody;
+  try {
+    body = (await request.json()) as RecoverRequestBody;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body.' }, { status: 400 });
+  }
+
+  const { txHash, action, contractId } = body;
+
+  if (!txHash) {
+    return NextResponse.json({ error: 'Missing required field: txHash' }, { status: 400 });
+  }
+  if (!action) {
+    return NextResponse.json({ error: 'Missing required field: action' }, { status: 400 });
+  }
+  if (!VALID_ACTIONS.includes(action)) {
+    return NextResponse.json(
+      { error: `Invalid action. Must be one of: ${VALID_ACTIONS.join(', ')}` },
+      { status: 400 },
+    );
+  }
+  if (!contractId) {
+    return NextResponse.json({ error: 'Missing required field: contractId' }, { status: 400 });
+  }
+
+  const missing = REQUIRED_FIELDS[action].filter((field) => body[field] === undefined);
+  if (missing.length > 0) {
+    return NextResponse.json(
+      { error: `${action} action requires: contractId, ${missing.join(', ')}` },
+      { status: 400 },
+    );
+  }
+
+  // TW indexer is idempotent; the Stellar tx already confirmed, so a re-index
+  // failure must not block our own DB correction.
+  try {
+    await trustlessWorkRequest('/indexer/update-from-txHash', {
+      method: 'POST',
+      body: { txHash },
+    });
+  } catch (error) {
+    console.error('[recover-from-txhash] TW indexer call failed:', error);
+  }
+
+  try {
+    const status = ACTION_STATUS[action];
+    const result = await updateEscrowStatusByContractId(contractId, status);
+
+    if (result.update_escrows.affected_rows === 0) {
+      return NextResponse.json(
+        { error: `No escrow record found for contractId: ${contractId}` },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json({ recovered: true, action, contractId, txHash, status });
+  } catch (error) {
+    if (error instanceof TrustlessWorkRequestError) {
+      return NextResponse.json(
+        { error: error.message, messages: error.messages, payload: error.payload },
+        { status: error.statusCode },
+      );
+    }
+
+    return NextResponse.json(
+      { error: getErrorMessages(error, 'Recovery DB update failed.') },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/frontend/src/lib/server/hasura.ts
+++ b/apps/frontend/src/lib/server/hasura.ts
@@ -111,3 +111,20 @@ export async function updateEscrowStatus(
     { engagement_id: engagementId, status },
   );
 }
+
+export async function updateEscrowStatusByContractId(
+  contractId: string,
+  status: string,
+): Promise<UpdateEscrowStatusResult> {
+  return hasuraRequest<UpdateEscrowStatusResult>(
+    `mutation UpdateEscrowStatusByContractId($contract_id: String!, $status: String!) {
+      update_escrows(
+        where: { contract_id: { _eq: $contract_id } }
+        _set: { status: $status }
+      ) {
+        affected_rows
+      }
+    }`,
+    { contract_id: contractId, status },
+  );
+}


### PR DESCRIPTION
 Closes #252

  ### What
  Adds a recovery endpoint that corrects SafeTrust's DB when a Stellar escrow
  transaction confirmed on-chain but the follow-up DB update in the normal
  send-transaction flow failed (network timeout, Hasura downtime, crash between
  the two steps).

  The endpoint:
  1. Re-indexes the tx in TrustlessWork via `POST /indexer/update-from-txHash`
     (idempotent; failure is logged, not fatal; the tx already confirmed).
  2. Corrects `escrows.status` for the matching `contract_id`.
  3. Returns `{ recovered: true, action, contractId, txHash, status }`.

  ### Note on scope
  The issue's sample code imports from `@/lib/server/escrow-db` (the six `db*`
  functions from "Issue 2"), which isn't merged on any branch. Rather than block
  or duplicate that work, this wires the endpoint to what actually exists: the
  `escrows` table via `hasura.ts`. I added `updateEscrowStatusByContractId()` and
  map each action to a real `escrows.status`:

  | action | status |
  |---|---|
  | initialize | pending_signature |
  | fund | funded |
  | approve_milestone | funded¹ |
  | release_funds | completed |
  | dispute | disputed |
  | resolve_dispute | resolved |

  ¹ the `escrows` table is single-release and has no distinct milestone status.

  ### Files
  - `app/api/escrow/recover-from-txhash/route.ts` new endpoint
  - `lib/server/hasura.ts` — `updateEscrowStatusByContractId()`
  - `app/api/escrow/recover-from-txhash/route.test.ts` 18 unit tests

<img width="2760" height="1420" alt="Screenshot 2026-07-21 121517" src="https://github.com/user-attachments/assets/f385f588-9c06-4a4a-9cc1-95bba444eb52" />

  ### Validation & tests
  - Validates `txHash`, `action`, `contractId`, and each action's required fields → `400`
  - Invalid action → `400` listing valid options
  - No matching escrow row → `404`; DB failure → `500`
  - **18 vitest tests pass** (mock Hasura + TW; no DB/network/key needed), covering
    the 400 paths, indexer-before-DB ordering, non-fatal indexer failure, all 6
    action→status mappings, and the 404/500 paths.
  - `tsc --noEmit` and `eslint` clean on changed files.

  ### Out of scope
  UI trigger, endpoint auth, and automatic retry — per the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an escrow recovery endpoint supporting transaction-hash recovery and action-specific validation.
  * Recovery re-indexes transaction data when available and updates the escrow status.
  * Responses now clearly report successful recovery, missing records, validation errors, and server failures.

* **Tests**
  * Added coverage for validation, status mapping, successful recovery, missing records, indexer failures, and database errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->