### PR TITLE
🧪[test]: unit tests for release-funds.handler.js

### DIFF
--- a/apps/api/src/routes/escrow/__tests__/release-funds.handler.test.js
+++ b/apps/api/src/routes/escrow/__tests__/release-funds.handler.test.js
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { releaseFundsHandler } from '../release-funds.handler.js';
+
+vi.mock('../../../lib/trustlesswork.js', () => ({
+  trustlessWork: { post: vi.fn() },
+}));
+
+import { trustlessWork } from '../../../lib/trustlesswork.js';
+
+const mockRes = () => {
+  const res = {};
+  res._status = undefined;
+  res._body = undefined;
+  res.status = (status) => {
+    res._status = status;
+    return res;
+  };
+  res.json = (body) => {
+    res._body = body;
+    return res;
+  };
+  return res;
+};
+
+describe('releaseFundsHandler', () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it('returns 400 when contractId is missing', async () => {
+    const res = mockRes();
+    await releaseFundsHandler({ body: { releaseSigner: 'GRELEASER' } }, res);
+    expect(res._status).toBe(400);
+    expect(res._body.error).toContain('contractId');
+    expect(trustlessWork.post).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when releaseSigner is missing', async () => {
+    const res = mockRes();
+    await releaseFundsHandler({ body: { contractId: 'CAZT001' } }, res);
+    expect(res._status).toBe(400);
+    expect(res._body.error).toContain('releaseSigner');
+    expect(trustlessWork.post).not.toHaveBeenCalled();
+  });
+
+  it('calls TrustlessWork /escrow/single-release/release-funds with correct body', async () => {
+    trustlessWork.post.mockResolvedValueOnce({
+      data: { unsignedTransaction: 'RELEASE_XDR_001' },
+    });
+
+    await releaseFundsHandler(
+      { body: { contractId: 'CAZT001', releaseSigner: 'GRELEASER' } },
+      mockRes(),
+    );
+
+    expect(trustlessWork.post).toHaveBeenCalledWith(
+      '/escrow/single-release/release-funds',
+      { contractId: 'CAZT001', releaseSigner: 'GRELEASER' },
+    );
+  });
+
+  it('returns 201 with unsignedTransaction on success', async () => {
+    trustlessWork.post.mockResolvedValueOnce({
+      data: { unsignedTransaction: 'RELEASE_XDR_001' },
+    });
+
+    const res = mockRes();
+    await releaseFundsHandler(
+      { body: { contractId: 'CAZT001', releaseSigner: 'GRELEASER' } },
+      res,
+    );
+
+    expect(res._status).toBe(201);
+    expect(res._body).toEqual({ unsignedTransaction: 'RELEASE_XDR_001' });
+  });
+
+  it('returns 500 on TrustlessWork network failure', async () => {
+    trustlessWork.post.mockRejectedValueOnce(new Error('Network timeout'));
+
+    const res = mockRes();
+    await releaseFundsHandler(
+      { body: { contractId: 'CAZT001', releaseSigner: 'GRELEASER' } },
+      res,
+    );
+
+    expect(res._status).toBe(500);
+    expect(res._body.error).toBe('Failed to release funds');
+  });
+});


### PR DESCRIPTION
Implements `apps/api/src/routes/escrow/__tests__/release-funds.handler.test.js` for issue #270.

Covers:
- 400 when `contractId` missing
- 400 when `releaseSigner` missing
- TrustlessWork `/escrow/single-release/release-funds` endpoint + payload shaping
- 201 response + `unsignedTransaction` shape
- 500 on TrustlessWork failure with `Failed to release funds`

Tests pass with Vitest on the new file. No app behavior change.

Closes #270

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for releasing escrow funds, including missing required information, successful requests, and network failures.
  * Verified appropriate response statuses and error messages for each scenario.

<!-- end of auto-generated comment: release notes by coderabbitai -->