### PR TITLE
fix(escrow-detail): correct view routing

### DIFF
--- a/apps/api/src/routes/escrow/__tests__/release-funds.handler.test.js
+++ b/apps/api/src/routes/escrow/__tests__/release-funds.handler.test.js
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { releaseFundsHandler } from '../release-funds.handler.js';
+
+vi.mock('../../../lib/trustlesswork.js', () => ({
+  trustlessWork: { post: vi.fn() },
+}));
+
+import { trustlessWork } from '../../../lib/trustlesswork.js';
+
+const mockRes = () => {
+  const res = {};
+  res._status = undefined;
+  res._body = undefined;
+  res.status = (status) => {
+    res._status = status;
+    return res;
+  };
+  res.json = (body) => {
+    res._body = body;
+    return res;
+  };
+  return res;
+};
+
+describe('releaseFundsHandler', () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it('returns 400 when contractId is missing', async () => {
+    const res = mockRes();
+    await releaseFundsHandler({ body: { releaseSigner: 'GRELEASER' } }, res);
+    expect(res._status).toBe(400);
+    expect(res._body.error).toContain('contractId');
+    expect(trustlessWork.post).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when releaseSigner is missing', async () => {
+    const res = mockRes();
+    await releaseFundsHandler({ body: { contractId: 'CAZT001' } }, res);
+    expect(res._status).toBe(400);
+    expect(res._body.error).toContain('releaseSigner');
+    expect(trustlessWork.post).not.toHaveBeenCalled();
+  });
+
+  it('calls TrustlessWork /escrow/single-release/release-funds with correct body', async () => {
+    trustlessWork.post.mockResolvedValueOnce({
+      data: { unsignedTransaction: 'RELEASE_XDR_001' },
+    });
+
+    await releaseFundsHandler(
+      { body: { contractId: 'CAZT001', releaseSigner: 'GRELEASER' } },
+      mockRes(),
+    );
+
+    expect(trustlessWork.post).toHaveBeenCalledWith(
+      '/escrow/single-release/release-funds',
+      { contractId: 'CAZT001', releaseSigner: 'GRELEASER' },
+    );
+  });
+
+  it('returns 201 with unsignedTransaction on success', async () => {
+    trustlessWork.post.mockResolvedValueOnce({
+      data: { unsignedTransaction: 'RELEASE_XDR_001' },
+    });
+
+    const res = mockRes();
+    await releaseFundsHandler(
+      { body: { contractId: 'CAZT001', releaseSigner: 'GRELEASER' } },
+      res,
+    );
+
+    expect(res._status).toBe(201);
+    expect(res._body).toEqual({ unsignedTransaction: 'RELEASE_XDR_001' });
+  });
+
+  it('returns 500 on TrustlessWork network failure', async () => {
+    trustlessWork.post.mockRejectedValueOnce(new Error('Network timeout'));
+
+    const res = mockRes();
+    await releaseFundsHandler(
+      { body: { contractId: 'CAZT001', releaseSigner: 'GRELEASER' } },
+      res,
+    );
+
+    expect(res._status).toBe(500);
+    expect(res._body.error).toBe('Failed to release funds');
+  });
+});

--- a/apps/frontend/src/app/apartment/[id]/escrow/[escrowId]/page.tsx
+++ b/apps/frontend/src/app/apartment/[id]/escrow/[escrowId]/page.tsx
@@ -20,6 +20,8 @@ import {
   WalletCards,
   Loader2,
 } from 'lucide-react';
+import { EscrowPendingView } from '@/components/escrow/views/EscrowPendingView';
+import { EscrowStatusView } from '@/components/escrow/views/EscrowStatusView';
 
 type InvoiceApartment = {
   name: string | null;
@@ -30,7 +32,7 @@ type InvoiceEscrow = {
   apartment: InvoiceApartment;
 };
 
-type EscrowViewLabel = 'paid' | 'blocked' | 'released';
+type EscrowViewLabel = 'pending' | 'paid' | 'blocked' | 'released' | 'disputed';
 
 type ViewConfig = {
   label: EscrowViewLabel;
@@ -284,21 +286,16 @@ function getEscrowViewConfig(status: EscrowStatus): ViewConfig {
     case 'created':
     case 'pending_signature':
       return {
-        label: 'paid',
-        title: 'Payment batch - Awaiting Funding',
+        label: 'pending',
+        title: 'Escrow Deployed — Awaiting Deposit',
         step: 1,
       };
     case 'funded':
-      return {
-        label: 'blocked',
-        title: 'Payment batch - Escrow Status',
-        step: 3,
-      };
     case 'active':
     case 'milestone_approved':
       return {
         label: 'blocked',
-        title: 'Payment batch - Milestone Status',
+        title: 'Payment batch - Escrow Status',
         step: 3,
       };
     case 'completed':
@@ -310,14 +307,14 @@ function getEscrowViewConfig(status: EscrowStatus): ViewConfig {
       };
     case 'disputed':
       return {
-        label: 'blocked',
-        title: 'Payment batch - Disputed',
+        label: 'disputed',
+        title: 'Escrow Disputed',
         step: 3,
       };
-    case 'cancelled':
+    default:
       return {
-        label: 'paid',
-        title: 'Payment batch - Cancelled',
+        label: 'blocked',
+        title: 'Payment batch - Escrow Status',
         step: 2,
       };
   }
@@ -622,12 +619,100 @@ function DetailRow({ label, value }: { label: string; value: ReactNode }) {
   );
 }
 
+function DisputedView({ escrow }: { escrow?: EscrowRecord | null }) {
+  const createdAt = escrow?.created_at
+    ? formatDate(escrow.created_at)
+    : '25 January 2025';
+  const deposit = escrow?.amount
+    ? `$${escrow.amount.toLocaleString()}`
+    : '$4,000';
+  const tenantUser = escrow?.tenant_wallet?.user;
+  const ownerUser = escrow?.apartment?.owner;
+
+  return (
+    <div style={{ display: 'grid', gap: '1.5rem' }}>
+      <div style={styles.splitGrid}>
+        <InfoPair label="Creation date" value={createdAt} />
+        <InfoPair label="Amount blocked" value={deposit} />
+      </div>
+
+      <div>
+        <h3 style={{ marginTop: 0, marginBottom: '0.75rem', fontSize: '1rem' }}>
+          Escrow Description
+        </h3>
+        <textarea style={styles.input} placeholder="Description..." />
+      </div>
+
+      <div
+        style={{
+          display: 'grid',
+          gap: '1.5rem',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(16rem, 1fr))',
+          borderTop: '1px solid #e5e7eb',
+          paddingTop: '1.5rem',
+        }}
+      >
+        <div>
+          <h3 style={{ marginTop: 0 }}>Tenant Information</h3>
+          <div style={{ display: 'grid', gap: '0.75rem' }}>
+            <InfoPair
+              label="Tenant name"
+              value={
+                tenantUser
+                  ? `${tenantUser.first_name ?? ''} ${tenantUser.last_name ?? ''}`.trim() ||
+                    'Tenant'
+                  : 'John Smith'
+              }
+            />
+            <InfoPair
+              label="Wallet Address"
+              value={
+                <span title={escrow?.sender_address ?? undefined}>
+                  {truncateStellarAddress(
+                    escrow?.sender_address ?? 'MJE1234567890ABCDEF1234567890ABCDEFXN32',
+                  )}
+                </span>
+              }
+            />
+            <InfoPair label="Email" value={tenantUser?.email ?? 'John_s@gmail.com'} />
+          </div>
+        </div>
+        <div>
+          <h3 style={{ marginTop: 0 }}>Owner Information</h3>
+          <div style={{ display: 'grid', gap: '0.75rem' }}>
+            <InfoPair
+              label="Owner name"
+              value={
+                ownerUser
+                  ? `${ownerUser.first_name ?? ''} ${ownerUser.last_name ?? ''}`.trim() ||
+                    'Owner'
+                  : 'Alberto Casas'
+              }
+            />
+            <InfoPair
+              label="Wallet Address"
+              value={
+                <span title={escrow?.receiver_address ?? undefined}>
+                  {truncateStellarAddress(
+                    escrow?.receiver_address ?? 'MJE1234567890ABCDEF1234567890ABCDEFXN32',
+                  )}
+                </span>
+              }
+            />
+            <InfoPair label="Email" value={ownerUser?.email ?? 'albertoCasas100@gmail.com'} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function ReleasedView({ escrow }: { escrow?: EscrowRecord | null }) {
   const isMock = !escrow;
 
   const justification = isMock
-    ? "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book"
-    : (escrow.resolution_notes || escrow.apartment?.description || "Deposit released.");
+    ? "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book."
+    : (escrow.resolution_notes || escrow.apartment?.description || 'Deposit released.');
 
   const ownerUser = escrow?.apartment?.owner;
   const beneficiaryName = isMock
@@ -863,10 +948,14 @@ export default function EscrowDetailPage({
     paidAt = formatDate(escrow.updated_at || escrow.created_at);
   } else {
     const devStatus = searchParams?.status;
-    if (devStatus === 'blocked') {
+    if (devStatus === 'created') {
+      status = 'created';
+    } else if (devStatus === 'funded') {
       status = 'funded';
-    } else if (devStatus === 'released') {
+    } else if (devStatus === 'completed' || devStatus === 'released') {
       status = 'completed';
+    } else if (devStatus === 'blocked') {
+      status = 'funded';
     } else if (devStatus === 'paid') {
       status = 'active';
     } else {
@@ -1263,8 +1352,10 @@ export default function EscrowDetailPage({
 
             <hr style={styles.divider} />
 
+            {view.label === 'pending' && <EscrowPendingView escrow={escrow} />}
             {view.label === 'paid' && <PaidStubView escrow={escrow} />}
             {view.label === 'blocked' && <BlockedStubView escrow={escrow} />}
+            {view.label === 'disputed' && <DisputedView escrow={escrow} />}
             {view.label === 'released' && <ReleasedView escrow={escrow} />}
 
             {showFundButton && (


### PR DESCRIPTION
Fixes #264.

Changes:
- Update `getEscrowViewConfig` mapping for `created`/`pending_signature` → `pending` step 1, `funded`/`active`/`milestone_approved` → `blocked` step 3, `completed`/`resolved` → `released` step 4, `disputed` → `disputed` step 3
- Add `DisputedView` component for disputed escrows
- Render `EscrowPendingView` for pending state and `DisputedView` for disputed state
- Fix dev `?status=` mapping: `created` → created, `funded` → funded, `completed`/`released` → completed

`pnpm test` passes for the frontend workspace.