### PR TITLE
feat: add validation and tests for deployEscrowHandler

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,7 +6,8 @@
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",
-    "dev": "nodemon src/index.js"
+    "dev": "nodemon src/index.js",
+    "test": "vitest run"
   },
   "dependencies": {
     "axios": "^1.18.0",
@@ -15,6 +16,7 @@
     "express": "^4.18.2"
   },
   "devDependencies": {
-    "nodemon": "^3.0.1"
+    "nodemon": "^3.0.1",
+    "vitest": "^3.2.4"
   }
 }

--- a/apps/api/src/routes/escrow/__tests__/deploy.handler.test.js
+++ b/apps/api/src/routes/escrow/__tests__/deploy.handler.test.js
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { deployEscrowHandler } from '../deploy.handler.js';
+
+vi.mock('../../../lib/trustlesswork.js', () => ({
+  trustlessWork: { post: vi.fn() },
+}));
+
+import { trustlessWork } from '../../../lib/trustlesswork.js';
+import { mockReq, mockRes } from './helpers.js';
+
+describe('deployEscrowHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.PLATFORM_STELLAR_ADDRESS = 'GPLATFORM111111111111111111111111111111111111111111111111';
+    process.env.PLATFORM_FEE_PERCENT = '1';
+  });
+
+  it('returns 400 when apartmentId is missing', async () => {
+    const res = mockRes();
+    await deployEscrowHandler(
+      mockReq({ tenantAddress: 'GTENANT', ownerAddress: 'GOWNER', amount: 1200, engagementId: 'ENG001' }),
+      res,
+    );
+
+    expect(res._status).toBe(400);
+  });
+
+  it('returns 400 when tenantAddress is missing', async () => {
+    const res = mockRes();
+    await deployEscrowHandler(
+      mockReq({ apartmentId: 'APT001', ownerAddress: 'GOWNER', amount: 1200, engagementId: 'ENG001' }),
+      res,
+    );
+
+    expect(res._status).toBe(400);
+  });
+
+  it('calls TrustlessWork with correct roles payload', async () => {
+    trustlessWork.post.mockResolvedValueOnce({
+      data: { unsignedTransaction: 'AAAA...XDR' },
+    });
+
+    await deployEscrowHandler(
+      mockReq({
+        apartmentId: 'APT001',
+        tenantAddress: 'GTENANT111111111111111111111111111111111111111111111111111',
+        ownerAddress: 'GOWNER111111111111111111111111111111111111111111111111111',
+        amount: 1200,
+        engagementId: 'ENG001',
+      }),
+      mockRes(),
+    );
+
+    expect(trustlessWork.post).toHaveBeenCalledWith(
+      '/deployer/single-release',
+      expect.objectContaining({
+        signer: 'GTENANT111111111111111111111111111111111111111111111111111',
+        engagementId: 'ENG001',
+        amount: 1200,
+        roles: expect.objectContaining({
+          approver: 'GTENANT111111111111111111111111111111111111111111111111111',
+          serviceProvider: 'GOWNER111111111111111111111111111111111111111111111111111',
+          receiver: 'GOWNER111111111111111111111111111111111111111111111111111',
+          platformAddress: 'GPLATFORM111111111111111111111111111111111111111111111111',
+          releaseSigner: 'GTENANT111111111111111111111111111111111111111111111111111',
+          disputeResolver: 'GPLATFORM111111111111111111111111111111111111111111111111',
+        }),
+      }),
+    );
+  });
+
+  it('returns 200 with unsignedXDR and engagementId on success', async () => {
+    trustlessWork.post.mockResolvedValueOnce({
+      data: { unsignedTransaction: 'AAAA...XDR' },
+    });
+
+    const res = mockRes();
+    await deployEscrowHandler(
+      mockReq({ apartmentId: 'APT001', tenantAddress: 'GTENANT', ownerAddress: 'GOWNER', amount: 1200, engagementId: 'ENG001' }),
+      res,
+    );
+
+    expect(res._status).toBe(200);
+    expect(res._body).toEqual({ unsignedXDR: 'AAAA...XDR', engagementId: 'ENG001' });
+  });
+
+  it('returns 400 for "amount cannot be zero" TrustlessWork error', async () => {
+    trustlessWork.post.mockRejectedValueOnce({
+      response: { data: { message: 'amount cannot be zero' } },
+      message: 'amount cannot be zero',
+    });
+
+    const res = mockRes();
+    await deployEscrowHandler(
+      mockReq({ apartmentId: 'APT001', tenantAddress: 'GTENANT', ownerAddress: 'GOWNER', amount: 0, engagementId: 'ENG001' }),
+      res,
+    );
+
+    expect(res._status).toBe(400);
+    expect(res._body.error).toBe('Amount cannot be zero');
+  });
+
+  it('returns 400 for "already initialized" TrustlessWork error', async () => {
+    trustlessWork.post.mockRejectedValueOnce({
+      response: { data: { message: 'already initialized' } },
+      message: 'already initialized',
+    });
+
+    const res = mockRes();
+    await deployEscrowHandler(
+      mockReq({ apartmentId: 'APT001', tenantAddress: 'GTENANT', ownerAddress: 'GOWNER', amount: 1200, engagementId: 'ENG001' }),
+      res,
+    );
+
+    expect(res._status).toBe(400);
+    expect(res._body.error).toBe('Escrow already initialized (duplicate engagementId)');
+  });
+
+  it('returns 400 for fee-related TrustlessWork errors', async () => {
+    trustlessWork.post.mockRejectedValueOnce({
+      response: { data: { message: 'fee cannot exceed 99%' } },
+      message: 'fee cannot exceed 99%',
+    });
+
+    const res = mockRes();
+    await deployEscrowHandler(
+      mockReq({ apartmentId: 'APT001', tenantAddress: 'GTENANT', ownerAddress: 'GOWNER', amount: 1200, engagementId: 'ENG001' }),
+      res,
+    );
+
+    expect(res._status).toBe(400);
+    expect(res._body.error).toBe('Platform fee cannot exceed 99%');
+  });
+
+  it('returns 400 for milestone-related TrustlessWork errors', async () => {
+    trustlessWork.post.mockRejectedValueOnce({
+      response: { data: { message: 'without milestone' } },
+      message: 'without milestone',
+    });
+
+    const res = mockRes();
+    await deployEscrowHandler(
+      mockReq({ apartmentId: 'APT001', tenantAddress: 'GTENANT', ownerAddress: 'GOWNER', amount: 1200, engagementId: 'ENG001' }),
+      res,
+    );
+
+    expect(res._status).toBe(400);
+    expect(res._body.error).toBe('Escrow initialized without milestone');
+  });
+
+  it('returns 400 for milestone count TrustlessWork errors', async () => {
+    trustlessWork.post.mockRejectedValueOnce({
+      response: { data: { message: 'more than 50 milestones' } },
+      message: 'more than 50 milestones',
+    });
+
+    const res = mockRes();
+    await deployEscrowHandler(
+      mockReq({ apartmentId: 'APT001', tenantAddress: 'GTENANT', ownerAddress: 'GOWNER', amount: 1200, engagementId: 'ENG001' }),
+      res,
+    );
+
+    expect(res._status).toBe(400);
+    expect(res._body.error).toBe('Cannot define more than 50 milestones');
+  });
+
+  it('returns 400 for flag TrustlessWork errors', async () => {
+    trustlessWork.post.mockRejectedValueOnce({
+      response: { data: { message: 'flags must be false' } },
+      message: 'flags must be false',
+    });
+
+    const res = mockRes();
+    await deployEscrowHandler(
+      mockReq({ apartmentId: 'APT001', tenantAddress: 'GTENANT', ownerAddress: 'GOWNER', amount: 1200, engagementId: 'ENG001' }),
+      res,
+    );
+
+    expect(res._status).toBe(400);
+    expect(res._body.error).toBe('All flags (approved, disputed, released) must be false');
+  });
+
+  it('returns 500 for unexpected TrustlessWork errors', async () => {
+    trustlessWork.post.mockRejectedValueOnce(new Error('Network timeout'));
+
+    const res = mockRes();
+    await deployEscrowHandler(
+      mockReq({ apartmentId: 'APT001', tenantAddress: 'GTENANT', ownerAddress: 'GOWNER', amount: 1200, engagementId: 'ENG001' }),
+      res,
+    );
+
+    expect(res._status).toBe(500);
+    expect(res._body.error).toBe('Failed to deploy escrow');
+  });
+});

--- a/apps/api/src/routes/escrow/__tests__/helpers.js
+++ b/apps/api/src/routes/escrow/__tests__/helpers.js
@@ -1,0 +1,20 @@
+export function mockReq(body = {}) {
+  return { body };
+}
+
+export function mockRes() {
+  const res = {
+    _status: null,
+    _body: undefined,
+    status(code) {
+      this._status = code;
+      return this;
+    },
+    json(payload) {
+      this._body = payload;
+      return this;
+    },
+  };
+
+  return res;
+}

--- a/apps/api/src/routes/escrow/deploy.handler.js
+++ b/apps/api/src/routes/escrow/deploy.handler.js
@@ -5,7 +5,20 @@ import { trustlessWork } from '../../lib/trustlesswork.js';
  * Receives escrow creation request, calls TrustlessWork, and returns unsigned XDR.
  */
 export async function deployEscrowHandler(req, res) {
-  const { apartmentId, tenantAddress, ownerAddress, amount, engagementId } = req.body;
+  const { apartmentId, tenantAddress, ownerAddress, amount, engagementId } = req.body || {};
+
+  const missing = [];
+  if (!apartmentId) missing.push('apartmentId');
+  if (!tenantAddress) missing.push('tenantAddress');
+  if (!ownerAddress) missing.push('ownerAddress');
+  if (amount === undefined || amount === null || amount === '') missing.push('amount');
+  if (!engagementId) missing.push('engagementId');
+
+  if (missing.length > 0) {
+    return res.status(400).json({
+      error: `Missing required field(s): ${missing.join(', ')}`,
+    });
+  }
 
   try {
     const response = await trustlessWork.post('/deployer/single-release', {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       nodemon:
         specifier: ^3.0.1
         version: 3.1.14
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.6(@types/node@20.19.37)(jiti@2.6.1)(yaml@2.8.3)
 
   apps/frontend:
     dependencies:
@@ -122,7 +125,7 @@ importers:
         version: 3.0.8
       lucide-react:
         specifier: latest
-        version: 1.25.0(react@18.3.1)
+        version: 1.27.0(react@18.3.1)
       motion:
         specifier: ^12.40.0
         version: 12.41.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -5161,8 +5164,8 @@ packages:
   lru_map@0.4.1:
     resolution: {integrity: sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==}
 
-  lucide-react@1.25.0:
-    resolution: {integrity: sha512-/mdJTRbiwcLOQ1NZZK1amZF9rIZyvO18D6r9TngE6TG1NmqHgFuT4eE7Xrkm9UsXMbBJD1NlfwHVltCDWHrOTw==}
+  lucide-react@1.27.0:
+    resolution: {integrity: sha512-rJicGl/3Fly/E0rOH1YmPZ6e49JCnKknh1ox1vpHnkfjujAkKA6sqUZvH3MTAaXXjgexyUwgNwTJzTtYuAFYJw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -10711,6 +10714,14 @@ snapshots:
     optionalDependencies:
       vite: 7.3.6(@types/node@20.19.37)(jiti@1.21.7)(yaml@2.8.3)
 
+  '@vitest/mocker@3.2.6(vite@7.3.6(@types/node@20.19.37)(jiti@2.6.1)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 3.2.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@20.19.37)(jiti@2.6.1)(yaml@2.8.3)
+
   '@vitest/pretty-format@3.2.6':
     dependencies:
       tinyrainbow: 2.0.0
@@ -13325,7 +13336,7 @@ snapshots:
 
   lru_map@0.4.1: {}
 
-  lucide-react@1.25.0(react@18.3.1):
+  lucide-react@1.27.0(react@18.3.1):
     dependencies:
       react: 18.3.1
 
@@ -15046,6 +15057,27 @@ snapshots:
       - tsx
       - yaml
 
+  vite-node@3.2.4(@types/node@20.19.37)(jiti@2.6.1)(yaml@2.8.3):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3(supports-color@5.5.0)
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.6(@types/node@20.19.37)(jiti@2.6.1)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite@7.3.6(@types/node@20.19.37)(jiti@1.21.7)(yaml@2.8.3):
     dependencies:
       esbuild: 0.28.1
@@ -15058,6 +15090,20 @@ snapshots:
       '@types/node': 20.19.37
       fsevents: 2.3.3
       jiti: 1.21.7
+      yaml: 2.8.3
+
+  vite@7.3.6(@types/node@20.19.37)(jiti@2.6.1)(yaml@2.8.3):
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.8
+      rollup: 4.62.2
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 20.19.37
+      fsevents: 2.3.3
+      jiti: 2.6.1
       yaml: 2.8.3
 
   vitest@3.2.6(@types/node@20.19.37)(jiti@1.21.7)(yaml@2.8.3):
@@ -15084,6 +15130,47 @@ snapshots:
       tinyrainbow: 2.0.0
       vite: 7.3.6(@types/node@20.19.37)(jiti@1.21.7)(yaml@2.8.3)
       vite-node: 3.2.4(@types/node@20.19.37)(jiti@1.21.7)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.37
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.2.6(@types/node@20.19.37)(jiti@2.6.1)(yaml@2.8.3):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.6
+      '@vitest/mocker': 3.2.6(vite@7.3.6(@types/node@20.19.37)(jiti@2.6.1)(yaml@2.8.3))
+      '@vitest/pretty-format': 3.2.6
+      '@vitest/runner': 3.2.6
+      '@vitest/snapshot': 3.2.6
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      debug: 4.4.3(supports-color@5.5.0)
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.6(@types/node@20.19.37)(jiti@2.6.1)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@20.19.37)(jiti@2.6.1)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.37


### PR DESCRIPTION
Closes #267 


Ran terminal command: pnpm --filter @safetrust/api test

## ✅ Deploy handler tests are now implemented and verified

The requested unit coverage for the escrow deploy flow is in place in deploy.handler.test.js, with shared test helpers in helpers.js.

### What changed
- Added tests for:
  - missing required fields validation
  - correct TrustlessWork payload construction, including the invariant that:
    - `roles.releaseSigner === tenantAddress`
    - `roles.receiver === ownerAddress`
  - success response shape
  - known TrustlessWork error mapping for the main error strings
  - unexpected error fallback behavior
- Updated deploy.handler.js to perform the required validation so the new tests pass.
- Added a runnable Vitest script in package.json.

### Verification
I ran:

```bash
pnpm --filter @safetrust/api test
```

Result:
- 1 test file passed
- 11 tests passed
- Duration: 1.09s

This completes the requested test coverage for the deploy handler.

Made changes.