### PR TITLE
fix(dApp-SafeTrust): fix-escrow-create-restore-pay-button-in-apartmen

### DIFF
--- a/apps/frontend/src/app/apartment/[id]/escrow/create/page.tsx
+++ b/apps/frontend/src/app/apartment/[id]/escrow/create/page.tsx
@@ -292,29 +292,30 @@ export default function EscrowCreatePage({
 
             {/* Apartment card + PAY button */}
             <ApartmentPropertyCard
-            name={apartment.name}
-            imageUrls={apartment.image_urls}
-            address={apartment.address}
-            description={apartment.description}
-            petFriendly={apartment.pet_friendly ?? false}
-            bedrooms={apartment.bedrooms}
-            bathrooms={apartment.bathrooms}
-            paySlot={
-              ownerWallet ? (
+              name={apartment.name}
+              imageUrls={apartment.image_urls}
+              address={apartment.address}
+              description={apartment.description}
+              petFriendly={apartment.pet_friendly ?? false}
+              bedrooms={apartment.bedrooms}
+              bathrooms={apartment.bathrooms}
+              paySlot={
                 <EscrowPayFlow
                   apartmentId={params.id}
                   apartmentName={apartment.name}
-                  ownerWalletAddress={ownerWallet}
+                  ownerWalletAddress={ownerWallet ?? ""}
                   amount={apartment.price}
                 />
-              ) : (
-                <p style={styles.walletDisabled}>
-                  Owner wallet is not available yet. Payment is disabled until
-                  the owner&apos;s Stellar wallet is linked.
-                </p>
-              )
-            }
-          />
+              }
+              belowHeadingSlot={
+                !ownerWallet ? (
+                  <p style={styles.walletDisabled}>
+                    Owner wallet is not available yet. Payment is disabled
+                    until the owner&apos;s Stellar wallet is linked.
+                  </p>
+                ) : null
+              }
+            />
 
             {/* Security deposit amount banner */}
             <div style={styles.amountBanner}>

--- a/apps/frontend/src/components/escrow/ApartmentPropertyCard.tsx
+++ b/apps/frontend/src/components/escrow/ApartmentPropertyCard.tsx
@@ -20,6 +20,7 @@ type ApartmentPropertyCardProps = {
   bedrooms?: number | null;
   bathrooms?: number | null;
   paySlot?: ReactNode;
+  belowHeadingSlot?: ReactNode;
 };
 
 const styles = {
@@ -29,6 +30,11 @@ const styles = {
     justifyContent: "space-between",
     gap: "1rem",
     flexWrap: "wrap",
+    borderBottom: "1px solid #f3f4f6",
+    paddingBottom: "1rem",
+  } satisfies CSSProperties,
+  paySlotWrap: {
+    flexShrink: 0,
   } satisfies CSSProperties,
   imageGrid: {
     display: "grid",
@@ -90,6 +96,7 @@ export function ApartmentPropertyCard({
   bedrooms,
   bathrooms,
   paySlot,
+  belowHeadingSlot,
 }: ApartmentPropertyCardProps) {
   const images = buildImageList(imageUrls);
   const addressLine = formatAddress(address);
@@ -98,8 +105,10 @@ export function ApartmentPropertyCard({
     <div style={{ display: "grid", gap: "1rem" }}>
       <div style={styles.headingRow}>
         <h2 style={{ margin: 0, fontSize: "1.5rem" }}>{name}</h2>
-        {paySlot}
+        {paySlot != null ? <div style={styles.paySlotWrap}>{paySlot}</div> : null}
       </div>
+
+      {belowHeadingSlot}
 
       <div style={styles.imageGrid}>
         {images.map((src, i) => (


### PR DESCRIPTION
Closes #276

## Summary
- fix(escrow-create): restore PAY button in ApartmentPropertyCard heading row and add divider line between title and image gallery

## Test plan
- [ ] Relevant tests pass locally
- [ ] Manual verification on affected UI or API paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated apartment escrow cards to display owner wallet availability messaging beneath the heading.
  * Improved card layout with clearer heading separation and payment section styling.
  * Payment flow remains consistently presented even when the owner wallet is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->